### PR TITLE
fix: wrong replaced tx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -163,31 +163,45 @@
       }
     },
     "@ledgerhq/hw-app-eth": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-2.2.0.tgz",
-      "integrity": "sha1-6LNZHrskVl1brLyl1MKgq5nrllo=",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-app-eth/-/hw-app-eth-4.21.0.tgz",
+      "integrity": "sha1-LYv75fCbkujWlRrmhQNtnVrqlv8=",
       "dev": true,
       "requires": {
-        "@ledgerhq/hw-transport": "2.2.0"
+        "@ledgerhq/hw-transport": "4.21.0"
       }
     },
     "@ledgerhq/hw-transport": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-2.2.0.tgz",
-      "integrity": "sha1-MtY3Tmz6y7S5sKVFzdL2vz1kYj8=",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-4.21.0.tgz",
+      "integrity": "sha1-UPhc/hFbo/nVv5R1XHAeknF1eU8=",
       "dev": true,
       "requires": {
-        "events": "1.1.1"
+        "events": "2.1.0"
       }
     },
     "@ledgerhq/hw-transport-u2f": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-2.2.0.tgz",
-      "integrity": "sha1-Um/tLv63W8zJrdyCbl06KKepXfY=",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-u2f/-/hw-transport-u2f-4.21.0.tgz",
+      "integrity": "sha1-hWldfoU6XCGvfn3LDOORnytlzdk=",
       "dev": true,
       "requires": {
-        "@ledgerhq/hw-transport": "2.2.0",
+        "@ledgerhq/hw-transport": "4.21.0",
         "u2f-api": "0.2.7"
+      }
+    },
+    "@ledgerhq/web3-subprovider": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/web3-subprovider/-/web3-subprovider-4.21.0.tgz",
+      "integrity": "sha1-t7q7PwfNlTaUaS0YHP7somN4kMg=",
+      "dev": true,
+      "requires": {
+        "@ledgerhq/hw-app-eth": "4.21.0",
+        "@ledgerhq/hw-transport": "4.21.0",
+        "@ledgerhq/hw-transport-u2f": "4.21.0",
+        "ethereumjs-tx": "1.3.7",
+        "strip-hex-prefix": "1.0.0",
+        "web3-provider-engine": "14.0.6"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -3727,22 +3741,6 @@
       "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true
     },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-      "dev": true,
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
-      }
-    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3862,6 +3860,12 @@
       "requires": {
         "async": "2.6.1"
       }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -4567,6 +4571,15 @@
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "dev": true,
+      "requires": {
+        "precond": "0.2.3"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -4668,16 +4681,6 @@
         "safe-buffer": "5.1.2"
       }
     },
-    "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.2"
-      }
-    },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -4760,7 +4763,7 @@
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000886",
+        "caniuse-lite": "1.0.30000887",
         "electron-to-chromium": "1.3.70"
       }
     },
@@ -4768,28 +4771,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
-      "dev": true
-    },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "dev": true,
-      "requires": {
-        "buffer-alloc-unsafe": "1.1.0",
-        "buffer-fill": "1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "dev": true
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
     },
     "buffer-from": {
@@ -4867,9 +4848,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000886",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000886.tgz",
-      "integrity": "sha512-xpYuY7rqc5+4q1n/l1BfSgIndaNqvXWKZ0Vk0ZXzVncCAkn0+huvIIPwcSL5YRJoW4MSRsgyNbjnKuh45GmknA==",
+      "version": "1.0.30000887",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000887.tgz",
+      "integrity": "sha512-AHpONWuGFWO8yY9igdXH94tikM6ERS84286r0cAMAXYFtJBk76lhiMhtCxBJNBZsD6hzlvpWZ2AtbVFEkf4JQA==",
       "dev": true
     },
     "cardinal": {
@@ -4944,12 +4925,6 @@
       "requires": {
         "functional-red-black-tree": "1.0.1"
       }
-    },
-    "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-      "dev": true
     },
     "ci-info": {
       "version": "1.5.1",
@@ -5110,11 +5085,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
+      }
     },
     "conventional-changelog-angular": {
       "version": "5.0.1",
@@ -5252,6 +5233,24 @@
         "sha.js": "2.4.11"
       }
     },
+    "cross-fetch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.2.tgz",
+      "integrity": "sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+          "dev": true
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -5349,19 +5348,19 @@
       }
     },
     "decentraland-eth": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/decentraland-eth/-/decentraland-eth-5.0.0.tgz",
-      "integrity": "sha512-Yafc9gM589JhXfi7AUDm0z5I/oGsMsB4hU3hHQNIlzUci6XD09V+GsHvxpkYpMrU0piwginEAmEGIKYbyJDeLQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decentraland-eth/-/decentraland-eth-6.0.0.tgz",
+      "integrity": "sha512-mqqIuYAwAtNr+xilR6RBwRdf3nfUnKDcdKhC3bLYVV//avRI5aaaEEVLRpmQ8VKA/duuAE7OmtyERjvGuvLo0g==",
       "dev": true,
       "requires": {
-        "@ledgerhq/hw-app-eth": "2.2.0",
-        "@ledgerhq/hw-transport-u2f": "2.2.0",
+        "@ledgerhq/hw-app-eth": "4.21.0",
+        "@ledgerhq/hw-transport-u2f": "4.21.0",
+        "@ledgerhq/web3-subprovider": "4.21.0",
         "comma-separated-values": "3.6.4",
         "ethereumjs-util": "5.2.0",
-        "ledger-wallet-provider": "2.0.0-beta.2",
         "npx": "10.2.0",
         "web3": "0.20.7",
-        "web3-provider-engine": "13.8.0"
+        "web3-provider-engine": "14.0.6"
       }
     },
     "decentraland-ui": {
@@ -5381,15 +5380,6 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
-    },
-    "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-      "dev": true,
-      "requires": {
-        "mimic-response": "1.0.1"
-      }
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -5483,12 +5473,6 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true
-    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -5497,12 +5481,6 @@
       "requires": {
         "repeating": "2.0.1"
       }
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "dev": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -5738,18 +5716,51 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "eth-block-tracker": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-2.3.1.tgz",
-      "integrity": "sha512-NamWuMBIl8kmkJFVj8WzGatySTzQPQag4Xr677yFxdVtIxACFbL/dQowk0MzEqIKk93U1TwY3MjVU6mOcwZnKA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
+      "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
       "dev": true,
       "requires": {
-        "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
         "eth-query": "2.1.2",
         "ethereumjs-tx": "1.3.7",
         "ethereumjs-util": "5.2.0",
         "ethjs-util": "0.1.6",
         "json-rpc-engine": "3.7.3",
         "pify": "2.3.0",
+        "tape": "4.9.1"
+      }
+    },
+    "eth-json-rpc-infura": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.1.2.tgz",
+      "integrity": "sha512-IuK5Iowfs6taluA/3Okmu6EfZcFMq6MQuyrUL1PrCoJstuuBr3TvVeSy3keDyxfbrjFB34nCo538I8G+qMtsbw==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "2.2.2",
+        "eth-json-rpc-middleware": "1.6.0",
+        "json-rpc-engine": "3.7.3",
+        "json-rpc-error": "2.0.0",
+        "tape": "4.9.1"
+      }
+    },
+    "eth-json-rpc-middleware": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
+      "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.1",
+        "eth-query": "2.1.2",
+        "eth-tx-summary": "3.2.3",
+        "ethereumjs-block": "1.7.1",
+        "ethereumjs-tx": "1.3.7",
+        "ethereumjs-util": "5.2.0",
+        "ethereumjs-vm": "2.4.0",
+        "fetch-ponyfill": "4.1.0",
+        "json-rpc-engine": "3.7.3",
+        "json-rpc-error": "2.0.0",
+        "json-stable-stringify": "1.0.1",
+        "promise-to-callback": "1.0.0",
         "tape": "4.9.1"
       }
     },
@@ -5771,6 +5782,97 @@
       "requires": {
         "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
         "ethereumjs-util": "5.2.0"
+      }
+    },
+    "eth-tx-summary": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.3.tgz",
+      "integrity": "sha512-1gZpA5fKarJOVSb5OUlPnhDQuIazqAkI61zlVvf5LdG47nEgw+/qhyZnuj3CUdE/TLTKuRzPLeyXLjaB4qWTRQ==",
+      "dev": true,
+      "requires": {
+        "async": "2.6.1",
+        "bn.js": "4.11.8",
+        "clone": "2.1.2",
+        "concat-stream": "1.6.2",
+        "end-of-stream": "1.4.1",
+        "eth-query": "2.1.2",
+        "ethereumjs-block": "1.7.1",
+        "ethereumjs-tx": "1.3.7",
+        "ethereumjs-util": "5.2.0",
+        "ethereumjs-vm": "2.3.4",
+        "through2": "2.0.3",
+        "treeify": "1.1.0",
+        "web3-provider-engine": "13.8.0"
+      },
+      "dependencies": {
+        "eth-block-tracker": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-2.3.1.tgz",
+          "integrity": "sha512-NamWuMBIl8kmkJFVj8WzGatySTzQPQag4Xr677yFxdVtIxACFbL/dQowk0MzEqIKk93U1TwY3MjVU6mOcwZnKA==",
+          "dev": true,
+          "requires": {
+            "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+            "eth-query": "2.1.2",
+            "ethereumjs-tx": "1.3.7",
+            "ethereumjs-util": "5.2.0",
+            "ethjs-util": "0.1.6",
+            "json-rpc-engine": "3.7.3",
+            "pify": "2.3.0",
+            "tape": "4.9.1"
+          }
+        },
+        "ethereum-common": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
+          "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
+          "dev": true
+        },
+        "ethereumjs-vm": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
+          "integrity": "sha512-Y4SlzNDqxrCO58jhp98HdnZVdjOqB+HC0hoU+N/DEp1aU+hFkRX/nru5F7/HkQRPIlA6aJlQp/xIA6xZs1kspw==",
+          "dev": true,
+          "requires": {
+            "async": "2.6.1",
+            "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+            "ethereum-common": "0.2.0",
+            "ethereumjs-account": "2.0.5",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-util": "5.2.0",
+            "fake-merkle-patricia-tree": "1.0.1",
+            "functional-red-black-tree": "1.0.1",
+            "merkle-patricia-tree": "2.3.2",
+            "rustbn.js": "0.1.2",
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "web3-provider-engine": {
+          "version": "13.8.0",
+          "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
+          "integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
+          "dev": true,
+          "requires": {
+            "async": "2.6.1",
+            "clone": "2.1.2",
+            "eth-block-tracker": "2.3.1",
+            "eth-sig-util": "1.4.2",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-tx": "1.3.7",
+            "ethereumjs-util": "5.2.0",
+            "ethereumjs-vm": "2.3.4",
+            "fetch-ponyfill": "4.1.0",
+            "json-rpc-error": "2.0.0",
+            "json-stable-stringify": "1.0.1",
+            "promise-to-callback": "1.0.0",
+            "readable-stream": "2.3.6",
+            "request": "2.88.0",
+            "semaphore": "1.1.0",
+            "solc": "0.4.25",
+            "tape": "4.9.1",
+            "xhr": "2.5.0",
+            "xtend": "4.0.1"
+          }
+        }
       }
     },
     "ethereum-blockies": {
@@ -5814,7 +5916,7 @@
         "ethereum-common": "0.2.0",
         "ethereumjs-tx": "1.3.7",
         "ethereumjs-util": "5.2.0",
-        "merkle-patricia-tree": "2.3.1"
+        "merkle-patricia-tree": "2.3.2"
       },
       "dependencies": {
         "ethereum-common": {
@@ -5870,9 +5972,17 @@
         "ethereumjs-util": "5.2.0",
         "fake-merkle-patricia-tree": "1.0.1",
         "functional-red-black-tree": "1.0.1",
-        "merkle-patricia-tree": "2.3.1",
+        "merkle-patricia-tree": "2.3.2",
         "rustbn.js": "0.2.0",
         "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "rustbn.js": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
+          "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
+          "dev": true
+        }
       }
     },
     "ethjs-util": {
@@ -5886,9 +5996,9 @@
       }
     },
     "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
       "dev": true
     },
     "evp_bytestokey": {
@@ -5959,12 +6069,6 @@
           }
         }
       }
-    },
-    "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
-      "dev": true
     },
     "extend": {
       "version": "3.0.2",
@@ -6274,12 +6378,6 @@
         "readable-stream": "2.3.6"
       }
     },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
-    },
     "fs-extra": {
       "version": "0.30.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
@@ -6309,22 +6407,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.3"
-      }
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -6417,12 +6499,6 @@
       "requires": {
         "git-up": "2.0.10"
       }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-      "dev": true
     },
     "glob": {
       "version": "7.1.2",
@@ -6577,12 +6653,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
@@ -7377,30 +7447,6 @@
         "invert-kv": "1.0.0"
       }
     },
-    "ledger-wallet-provider": {
-      "version": "2.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/ledger-wallet-provider/-/ledger-wallet-provider-2.0.0-beta.2.tgz",
-      "integrity": "sha512-A3VE7dU7bGR7weyF0Vh9RmaZaLMxbeJ/7/O35Y5GS69oGpsuQgDRdwW8VEV09Bp5R5u3I6cWHa9MdxouO/0qgQ==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "ethereumjs-tx": "1.3.7",
-        "ledgerco": "1.2.1",
-        "promise-timeout": "1.3.0",
-        "strip-hex-prefix": "1.0.0",
-        "web3-provider-engine": "13.8.0"
-      }
-    },
-    "ledgerco": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ledgerco/-/ledgerco-1.2.1.tgz",
-      "integrity": "sha1-of3v16r1qIV7+bR4h/VGW9zfBgI=",
-      "dev": true,
-      "requires": {
-        "node-hid": "0.6.0",
-        "u2f-api": "0.2.7"
-      }
-    },
     "level-codec": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
@@ -7879,9 +7925,9 @@
       "dev": true
     },
     "merkle-patricia-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
-      "integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.2.tgz",
+      "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
       "dev": true,
       "requires": {
         "async": "1.5.2",
@@ -7948,12 +7994,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
-    },
-    "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "dev": true
     },
     "min-document": {
@@ -8132,15 +8172,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-abi": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.4.tgz",
-      "integrity": "sha512-DQ9Mo2mf/XectC+s6+grPPRQ1Z9gI3ZbrGv6nyXRkjwT3HrE0xvtvrfnH7YHYBLgC/KLadg+h3XHnhZw1sv88A==",
-      "dev": true,
-      "requires": {
-        "semver": "5.5.0"
-      }
-    },
     "node-emoji": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
@@ -8159,23 +8190,6 @@
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
       }
-    },
-    "node-hid": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-0.6.0.tgz",
-      "integrity": "sha512-3fOES92dR7vD5Fb6p28+/hRNmBFYicv/FDMj/d/U2O1Nb4GMpzSf9/HUvewRVVS0JQb6aoLMsxVpAFdIt4U/eA==",
-      "dev": true,
-      "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.11.0",
-        "prebuild-install": "2.5.3"
-      }
-    },
-    "noop-logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-      "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
@@ -8208,18 +8222,6 @@
       "dev": true,
       "requires": {
         "path-key": "2.0.1"
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "1.1.5",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
       }
     },
     "npx": {
@@ -14536,28 +14538,11 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-      "dev": true,
-      "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.1",
-        "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.4.4",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.8",
-        "simple-get": "2.8.1",
-        "tar-fs": "1.16.3",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
-      }
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw=",
+      "dev": true
     },
     "prettier": {
       "version": "1.14.1",
@@ -14591,12 +14576,6 @@
       "requires": {
         "asap": "2.0.6"
       }
-    },
-    "promise-timeout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/promise-timeout/-/promise-timeout-1.3.0.tgz",
-      "integrity": "sha512-5yANTE0tmi5++POym6OgtFmwfDvOXABD9oj/jLQr5GPEyuNEb7jH4wbbANJceJid49jwhi1RddxnhnEAb/doqg==",
-      "dev": true
     },
     "promise-to-callback": {
       "version": "1.0.0",
@@ -14635,16 +14614,6 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
       "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
       "dev": true
-    },
-    "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
-      }
     },
     "punycode": {
       "version": "1.4.1",
@@ -15100,9 +15069,9 @@
       }
     },
     "rustbn.js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
-      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.1.2.tgz",
+      "integrity": "sha512-bAkNqSHYdJdFsBC7Z11JgzYktL31HIpB2o70jZcGiL1U1TVtPyvaVhDrGWwS8uZtaqwW2k6NOPGZCqW/Dgh5Lg==",
       "dev": true
     },
     "safe-buffer": {
@@ -15553,23 +15522,6 @@
         "pkg-conf": "2.1.0"
       }
     },
-    "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-      "dev": true
-    },
-    "simple-get": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-      "dev": true,
-      "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
-      }
-    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -15980,45 +15932,6 @@
         }
       }
     },
-    "tar-fs": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
-      "dev": true,
-      "requires": {
-        "chownr": "1.1.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.6.1"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
-          }
-        }
-      }
-    },
-    "tar-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
-      "dev": true,
-      "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.2.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.6",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
-      }
-    },
     "text-extensions": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.8.0.tgz",
@@ -16040,12 +15953,6 @@
         "readable-stream": "2.3.6",
         "xtend": "4.0.1"
       }
-    },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -16109,6 +16016,12 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "dev": true
+    },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
       "dev": true
     },
     "trim": {
@@ -16313,6 +16226,12 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
     "typesafe-actions": {
@@ -16543,28 +16462,30 @@
       }
     },
     "web3-provider-engine": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
-      "integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.0.6.tgz",
+      "integrity": "sha512-tr5cGSyxfSC/JqiUpBlJtfZpwQf1yAA8L/zy1C6fDFm0ntR974pobJ4v4676atpZne4Ze5VFy3kPPahHe9gQiQ==",
       "dev": true,
       "requires": {
         "async": "2.6.1",
+        "backoff": "2.5.0",
         "clone": "2.1.2",
-        "eth-block-tracker": "2.3.1",
+        "cross-fetch": "2.2.2",
+        "eth-block-tracker": "3.0.1",
+        "eth-json-rpc-infura": "3.1.2",
         "eth-sig-util": "1.4.2",
         "ethereumjs-block": "1.7.1",
         "ethereumjs-tx": "1.3.7",
         "ethereumjs-util": "5.2.0",
         "ethereumjs-vm": "2.4.0",
-        "fetch-ponyfill": "4.1.0",
         "json-rpc-error": "2.0.0",
         "json-stable-stringify": "1.0.1",
         "promise-to-callback": "1.0.0",
         "readable-stream": "2.3.6",
         "request": "2.88.0",
         "semaphore": "1.1.0",
-        "solc": "0.4.25",
         "tape": "4.9.1",
+        "ws": "5.2.2",
         "xhr": "2.5.0",
         "xtend": "4.0.1"
       }
@@ -16589,21 +16510,6 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
       "dev": true
-    },
-    "which-pm-runs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-      "dev": true
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2"
-      }
     },
     "window-size": {
       "version": "0.2.0",
@@ -16631,6 +16537,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "1.0.0"
+      }
     },
     "xhr": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/mocha": "^5.2.5",
     "chai": "^4.1.2",
     "dcl-tslint-config-standard": "^1.0.1",
-    "decentraland-eth": "^5.0.0",
+    "decentraland-eth": "^6.0.0",
     "decentraland-ui": "^1.8.0",
     "husky": "^0.14.3",
     "mocha": "^5.2.0",
@@ -57,7 +57,7 @@
     "validate-commit-message": "^3.0.1"
   },
   "peerDependencies": {
-    "decentraland-eth": ">=5.0.0",
+    "decentraland-eth": ">=6.0.0",
     "decentraland-ui": "^1.8.0",
     "react": "^16.4.1",
     "react-redux": "^5.0.7",

--- a/src/modules/transaction/sagas.ts
+++ b/src/modules/transaction/sagas.ts
@@ -187,7 +187,15 @@ function* handleReplaceTransactionRequest(
 
     // if a replacement tx was found, replace it
     if (replacedBy) {
-      yield put(replaceTransactionSuccess(hash, replacedBy.hash))
+      // this is a tx that was wrongly marked as replaced
+      // could be due to a race condition when fetching the account nonce
+      // it will be sent back to the pending tx saga that will mark it as confirmed/reverted
+      if (hash === replacedBy.hash) {
+        yield put(fetchTransactionRequest(account, hash, buildActionRef(tx)))
+      } else {
+        // replacement found!
+        yield put(replaceTransactionSuccess(hash, replacedBy.hash))
+      }
       break
     }
 


### PR DESCRIPTION
This PR changes the way we handle `replaced` transactions, so they are instead treated as dropped (marked as dropped in the state, and letting the saga find it's replacement).

This is better in the following ways: 

1. The saga can find the actual replacement transaction, and store its hash in the state, so we can show a proper link to the user

2. If the transaction is wrongly marked as replaced (due to a race condition or two unsynced nodes sitting behind a load balancer) instead of going to a final state (replaced) it will go to a polling state (dropped) which can fix the wrong state by finding a replacement transaction that matches the hash of the original transaction. If this happens the transaction is sent back to the pending transactions saga, that will ultimately change its status to confirmed or reverted.