### PR TITLE
feat: clear transactions

### DIFF
--- a/src/modules/transaction/actions.ts
+++ b/src/modules/transaction/actions.ts
@@ -120,3 +120,29 @@ export type ReplaceTransactionSuccessAction = ReturnType<
 export type ReplaceTransactionFailureAction = ReturnType<
   typeof replaceTransactionFailure
 >
+
+// Clear Transactions (multiple)
+
+export const CLEAR_TRANSACTIONS = 'Clear Transactions'
+
+export const clearTransactions = (
+  address: string,
+  clearPendings: boolean = false
+) =>
+  action(CLEAR_TRANSACTIONS, {
+    address,
+    clearPendings
+  })
+
+export type ClearTransactionsAction = ReturnType<typeof clearTransactions>
+
+// Clear Transaction (single)
+
+export const CLEAR_TRANSACTION = 'Clear Transaction'
+
+export const clearTransaction = (hash: string) =>
+  action(CLEAR_TRANSACTION, {
+    hash
+  })
+
+export type ClearTransactionAction = ReturnType<typeof clearTransaction>

--- a/src/modules/transaction/reducer.ts
+++ b/src/modules/transaction/reducer.ts
@@ -13,9 +13,14 @@ import {
   UPDATE_TRANSACTION_NONCE,
   UpdateTransactionNonceAction,
   REPLACE_TRANSACTION_SUCCESS,
-  ReplaceTransactionSuccessAction
+  ReplaceTransactionSuccessAction,
+  ClearTransactionsAction,
+  ClearTransactionAction,
+  CLEAR_TRANSACTIONS,
+  CLEAR_TRANSACTION
 } from './actions'
 import { txUtils } from 'decentraland-eth'
+import { isPending } from './utils'
 
 export type TransactionState = {
   data: Transaction[]
@@ -36,6 +41,8 @@ export type TransactionReducerAction =
   | UpdateTransactionStatusAction
   | UpdateTransactionNonceAction
   | ReplaceTransactionSuccessAction
+  | ClearTransactionsAction
+  | ClearTransactionAction
 
 export function transactionReducer(
   state = INITIAL_STATE,
@@ -143,6 +150,24 @@ export function transactionReducer(
                   replacedBy: action.payload.replaceBy
                 }
               : transaction
+        )
+      }
+    }
+    case CLEAR_TRANSACTIONS: {
+      return {
+        ...state,
+        data: state.data.filter(
+          transaction =>
+            transaction.from !== action.payload.address &&
+            (action.payload.clearPendings || !isPending(transaction.status))
+        )
+      }
+    }
+    case CLEAR_TRANSACTION: {
+      return {
+        ...state,
+        data: state.data.filter(
+          transaction => transaction.hash !== action.payload.hash
         )
       }
     }


### PR DESCRIPTION
This PR adds two synchronous actions to the `transaction` module:

```ts
clearTransactions(address: string, clearPendings: boolean = false)
```

Removes from the state all the transaction history for a given address. If the second param is set to `true` it also removes the pending transactions (default is `false`).

```ts
clearTransaction(hash: string)
```

Removes a single transaction from the state, by its tx hash.