### PR TITLE
chore: remove unsued dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ jobs:
           keys:
             - dependencies-{{ checksum "package-lock.json" }}
       - run:
-          name: Install system dependencies
-          command: sudo apt-get update && sudo apt install -y libusb-1.0-0 libusb-1.0-0-dev
-      - run:
           name: Install node dependencies
           command: npm install
       - save_cache:
@@ -36,9 +33,6 @@ jobs:
       - restore_cache:
           keys:
             - dependencies-{{ checksum "package-lock.json" }}
-      - run:
-          name: Install system dependencies
-          command: sudo apt-get update && sudo apt install -y libusb-1.0-0 libusb-1.0-0-dev
       - run:
           name: Install node dependencies
           command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:8.9.4
+      - image: circleci/node:10
 
     working_directory: /tmp/decentraland-dapps
 
@@ -24,7 +24,7 @@ jobs:
 
   build:
     docker:
-      - image: circleci/node:8.9.4
+      - image: circleci/node:10
 
     working_directory: /tmp/decentraland-dapps
 
@@ -46,7 +46,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:8.9.4
+      - image: circleci/node:10
 
     working_directory: /tmp/decentraland-dapps
 


### PR DESCRIPTION
This PR removes the system dependencies on `libusb` since they are not required anymore by `decentraland-eth`. It also allow us to move to node 10.