### PR TITLE
fix: repeated transactions

### DIFF
--- a/src/modules/transaction/reducer.ts
+++ b/src/modules/transaction/reducer.ts
@@ -52,11 +52,14 @@ export function transactionReducer(
     case FETCH_TRANSACTION_REQUEST: {
       const actionRef = action.payload.action
       const transaction = getTransactionFromAction(actionRef)
+      const otherTransactions = state.data.filter(
+        otherTransaction => otherTransaction.hash !== transaction.hash
+      )
       return {
         loading: loadingReducer(state.loading, action),
         error: null,
         data: [
-          ...state.data,
+          ...otherTransactions,
           {
             ...transaction,
             timestamp: Date.now(),


### PR DESCRIPTION
This PR fixes a bug that causes transactions to be repeated in the app state.

In some edge scenarios we dispatch `FETCH_TRANSACTION_REQUEST` actions of transactions that are already in the state:

1. When a transaction is dropped momentarily (ie the node responds `null` for it's status) and moments later comes back. In that scenario the transaction would be on the saga that watches dropped transactions and it would be sent back to the saga that watches pending transactions. This is where that happens: [LINK](https://github.com/decentraland/decentraland-dapps/blob/master/src/modules/transaction/sagas.ts#L160). That works fine at the saga level, but in the reducer a new transaction in "loading" or `null` status is inserted (which is good) because it will be picked up and updated by the pending tx saga, but the old transaction remains in the state, which is bad.

2. We also dispatch a `FETCH_TRANSACTION_REQUEST` when a transaction is dropped and then replaced by itself. This happens in the scenario that a transaction is momentarily dropped by a node, but then it gets mined before we get to know it (it can be a race condition, or the user closed the browser while the transaction was in dropped status). So what happens is that the transaction is found to be replaced, but the replacement hash matches the original hash: in that case we [send it back as pending](https://github.com/decentraland/decentraland-dapps/blob/master/src/modules/transaction/sagas.ts#L198), and the pending saga then marks it as confirmed/reverted. But again, we want the old dropped transaction to be removed from the  state otherwise we end up with 2 transactions.

These edge cases are hard to reproduce (basically because we need a transaction to be dropped only for a few moments) but I hope the explanation makes clear the reasoning behind the changes.