### PR TITLE
feat: watch reverted transactions

### DIFF
--- a/src/modules/transaction/actions.ts
+++ b/src/modules/transaction/actions.ts
@@ -90,6 +90,17 @@ export type WatchDroppedTransactionsAction = ReturnType<
   typeof watchDroppedTransactions
 >
 
+// Watch reverted transaction
+
+export const WATCH_REVERTED_TRANSACTION = 'Watch Reverted Transaction'
+
+export const watchRevertedTransaction = (hash: string) =>
+  action(WATCH_REVERTED_TRANSACTION, { hash })
+
+export type WatchRevertedTransactionAction = ReturnType<
+  typeof watchRevertedTransaction
+>
+
 // Replace transaction
 
 export const REPLACE_TRANSACTION_REQUEST = '[Request] Replace Transaction'

--- a/src/modules/transaction/sagas.ts
+++ b/src/modules/transaction/sagas.ts
@@ -24,26 +24,34 @@ import {
   WATCH_DROPPED_TRANSACTIONS,
   replaceTransactionSuccess,
   REPLACE_TRANSACTION_REQUEST,
-  fetchTransactionRequest
+  fetchTransactionRequest,
+  watchRevertedTransaction,
+  WatchRevertedTransactionAction,
+  WATCH_REVERTED_TRANSACTION
 } from './actions'
 import {
   CONNECT_WALLET_SUCCESS,
   ConnectWalletSuccessAction
 } from '../wallet/actions'
-import { getData, getTransaction } from './selectors'
+import { getData, getTransaction, getTransactions } from './selectors'
 import { isPending, buildActionRef } from './utils'
 import { TransactionStatus } from 'decentraland-eth/dist/ethereum/wallets/Wallet'
+import { getAddress } from '../wallet/selectors'
+
+const { TRANSACTION_TYPES } = txUtils
 
 export function* transactionSaga(): IterableIterator<ForkEffect> {
   yield takeEvery(FETCH_TRANSACTION_REQUEST, handleFetchTransactionRequest)
   yield takeEvery(REPLACE_TRANSACTION_REQUEST, handleReplaceTransactionRequest)
   yield takeEvery(WATCH_PENDING_TRANSACTIONS, handleWatchPendingTransactions)
   yield takeEvery(WATCH_DROPPED_TRANSACTIONS, handleWatchDroppedTransactions)
+  yield takeEvery(WATCH_REVERTED_TRANSACTION, handleWatchRevertedTransaction)
   yield takeEvery(CONNECT_WALLET_SUCCESS, handleConnectWalletSuccess)
 }
 
 const BLOCKS_DEPTH = 100
-const PENDING_TRANSACTION_THRESHOLD = 72 * 60 * 60 * 1000 // 72hs
+const PENDING_TRANSACTION_THRESHOLD = 72 * 60 * 60 * 1000 // 72 hours
+const REVERTED_TRANSACTION_THRESHOLD = 60 * 60 * 1000 // 1 hour
 
 const watchPendingIndex: { [hash: string]: boolean } = {
   // hash: true
@@ -80,7 +88,7 @@ function* handleFetchTransactionRequest(action: FetchTransactionRequestAction) {
     while (
       isUnknown ||
       isPending(tx.type) ||
-      tx.type === txUtils.TRANSACTION_TYPES.replaced // let replaced transactions be kept in the loop so it can be picked up as dropped
+      tx.type === TRANSACTION_TYPES.replaced // let replaced transactions be kept in the loop so it can be picked up as dropped
     ) {
       const txInState: Transaction = yield select(state =>
         getTransaction(state, hash)
@@ -102,15 +110,11 @@ function* handleFetchTransactionRequest(action: FetchTransactionRequestAction) {
       if (statusInState !== statusInNetwork && nonce != null) {
         // check if dropped or replaced
         const isDropped = statusInState != null && statusInNetwork == null
-        const isReplaced =
-          statusInNetwork === txUtils.TRANSACTION_TYPES.replaced
+        const isReplaced = statusInNetwork === TRANSACTION_TYPES.replaced
         if (isDropped || isReplaced) {
           // mark tx as dropped even if it was returned with a 'replaced' status, let the saga find its replacement
           yield put(replaceTransactionRequest(hash, nonce))
-          throw new FailedTransactionError(
-            hash,
-            txUtils.TRANSACTION_TYPES.dropped
-          )
+          throw new FailedTransactionError(hash, TRANSACTION_TYPES.dropped)
         }
         yield put(updateTransactionStatus(hash, statusInNetwork))
       }
@@ -125,7 +129,7 @@ function* handleFetchTransactionRequest(action: FetchTransactionRequestAction) {
 
     delete watchPendingIndex[hash]
 
-    if (tx.type === 'confirmed') {
+    if (tx.type === TRANSACTION_TYPES.confirmed) {
       yield put(
         fetchTransactionSuccess({
           ...transaction,
@@ -136,6 +140,9 @@ function* handleFetchTransactionRequest(action: FetchTransactionRequestAction) {
         })
       )
     } else {
+      if (tx.type === TRANSACTION_TYPES.reverted) {
+        yield put(watchRevertedTransaction(tx.hash))
+      }
       throw new FailedTransactionError(tx.hash, tx.type)
     }
   } catch (error) {
@@ -218,10 +225,7 @@ function* handleReplaceTransactionRequest(
     // if there was nonce higher to than the one in the tx, we can mark it as replaced (altough we don't know which tx replaced it)
     if (highestNonce >= nonce) {
       yield put(
-        updateTransactionStatus(
-          action.payload.hash,
-          txUtils.TRANSACTION_TYPES.replaced
-        )
+        updateTransactionStatus(action.payload.hash, TRANSACTION_TYPES.replaced)
       )
       break
     }
@@ -249,9 +253,7 @@ function* handleWatchPendingTransactions() {
         )
       } else {
         // mark it as dropped if it's too old
-        yield put(
-          updateTransactionStatus(tx.hash, txUtils.TRANSACTION_TYPES.dropped)
-        )
+        yield put(updateTransactionStatus(tx.hash, TRANSACTION_TYPES.dropped))
       }
     }
   }
@@ -261,7 +263,7 @@ function* handleWatchDroppedTransactions() {
   const transactions: Transaction[] = yield select(getData)
   const droppedTransactions = transactions.filter(
     transaction =>
-      transaction.status === txUtils.TRANSACTION_TYPES.dropped &&
+      transaction.status === TRANSACTION_TYPES.dropped &&
       transaction.nonce != null
   )
 
@@ -275,7 +277,45 @@ function* handleWatchDroppedTransactions() {
   }
 }
 
+function* handleWatchRevertedTransaction(
+  action: WatchRevertedTransactionAction
+) {
+  const { hash } = action.payload
+
+  const txInState: Transaction = yield select(state =>
+    getTransaction(state, hash)
+  )
+
+  if (txInState.status !== TRANSACTION_TYPES.reverted) {
+    return
+  }
+
+  do {
+    const tx: txUtils.Transaction | null = yield call(() =>
+      txUtils.getTransaction(hash)
+    )
+    if (tx != null && tx.type === TRANSACTION_TYPES.confirmed) {
+      yield put(updateTransactionStatus(hash, TRANSACTION_TYPES.confirmed))
+      break
+    }
+  } while (txInState.timestamp > Date.now() - REVERTED_TRANSACTION_THRESHOLD)
+}
+
 function* handleConnectWalletSuccess(_: ConnectWalletSuccessAction) {
   yield put(watchPendingTransactions())
   yield put(watchDroppedTransactions())
+
+  // find reverted transactions and watch the latest ones
+  const address: string = yield select(state => getAddress(state))
+  const transactions: Transaction[] = yield select(state =>
+    getTransactions(state, address)
+  )
+  const revertedTransactions = transactions.filter(
+    transaction =>
+      transaction.status === TRANSACTION_TYPES.reverted &&
+      transaction.timestamp > Date.now() - REVERTED_TRANSACTION_THRESHOLD
+  )
+  for (const transaction of revertedTransactions) {
+    yield put(watchRevertedTransaction(transaction.hash))
+  }
 }

--- a/src/modules/transaction/sagas.ts
+++ b/src/modules/transaction/sagas.ts
@@ -297,7 +297,7 @@ function* handleWatchRevertedTransaction(
     )
     if (tx != null && tx.type === TRANSACTION_TYPES.confirmed) {
       yield put(updateTransactionStatus(hash, TRANSACTION_TYPES.confirmed))
-      break
+      return
     }
   } while (txInState.timestamp > Date.now() - REVERTED_TRANSACTION_THRESHOLD)
 }

--- a/src/modules/transaction/sagas.ts
+++ b/src/modules/transaction/sagas.ts
@@ -291,6 +291,7 @@ function* handleWatchRevertedTransaction(
   }
 
   do {
+    yield call(delay, txUtils.TRANSACTION_FETCH_DELAY)
     const tx: txUtils.Transaction | null = yield call(() =>
       txUtils.getTransaction(hash)
     )


### PR DESCRIPTION
This PR adds a feature: watch reverted transactions for up to an hour and if the transaction is found to be confirmed, it updates its status.

This is because sometimes transactions are found to be reverted at first when they get mined (because they have a `blockNumber` in their tx status but no receipt). This happens more often in mainnet.

# How to test

You can just install `decentraland-dapps@rc` in the marketplace repo, then run this code at the console to turn your confirmed transactions into reverted ones:

```js
const storage = JSON.parse(localStorage['decentraland-marketplace'])
storage.transaction.data.forEach(tx => {
  if (tx.status === 'confirmed') {
    tx.status = "reverted"
    tx.timestamp = Date.now() - 1000
  }
})
localStorage['decentraland-marketplace'] = JSON.stringify(storage)
```

Then go to activity page and refresh the page. You should see all the transactions fixed as Accepted again, and if you open the console you will see a bunch of `Watch Reverted Transaction` actions followed by a bunch of `Update Transaction Status` actions that fix all the wrong statuses. 