### PR TITLE
feat: support approbable wallets

### DIFF
--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -7,17 +7,17 @@ import {
   all
 } from 'redux-saga/effects'
 import { eth, Contract } from 'decentraland-eth'
-import { BaseWallet } from './types'
+import { EthereumWindow, BaseWallet } from './types'
 import {
   connectWalletSuccess,
   connectWalletFailure,
   CONNECT_WALLET_REQUEST
 } from './actions'
-import { connectEthereumWallet } from './utils'
+import { isApprovableWallet, connectEthereumWallet } from './utils'
 import { getData } from './selectors'
 
 export type WalletSagaOptions = {
-  provider: string
+  provider: object | string
   contracts: Contract[]
   eth: typeof eth
 }
@@ -29,6 +29,17 @@ export function createWalletSaga({
 }: WalletSagaOptions): () => IterableIterator<ForkEffect> {
   function* handleConnectWalletRequest() {
     try {
+      if (isApprovableWallet()) {
+        const { ethereum } = window as EthereumWindow
+        yield call(() => ethereum!.enable())
+
+        // Unfortunately we need to override the provider supplied to this method
+        // if we're dealing with approbable wallets (the first being Metamask, probably more to come).
+        // When a wallet is needs to call `enable` to work (to whitelist the URL), the correct provider is `ethereum`
+        // but if we're using a different kind of wallet (like a Ledger) the user supplied provider should be ok.
+        provider = ethereum!
+      }
+
       const walletData: BaseWallet = yield select(getData)
 
       yield call(() =>

--- a/src/modules/wallet/types.ts
+++ b/src/modules/wallet/types.ts
@@ -17,3 +17,10 @@ export interface BaseWallet {
   locale?: string
   derivationPath?: string
 }
+
+export interface EthereumWindow {
+  ethereum?: {
+    isApproved: () => Promise<boolean>
+    enable: () => Promise<string[]>
+  }
+}

--- a/src/modules/wallet/types.ts
+++ b/src/modules/wallet/types.ts
@@ -20,7 +20,9 @@ export interface BaseWallet {
 
 export interface EthereumWindow {
   ethereum?: {
+    _metamask: { isApproved: () => Promise<boolean> }
     isApproved: () => Promise<boolean>
+
     enable: () => Promise<string[]>
   }
 }

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -65,5 +65,6 @@ export async function isWalletApproved() {
 
   // `isApproved` is not standard. It's supported by MetaMask and it's expected to be implemented by other wallet vendors
   // but we need to check just in case.
-  return ethereum.isApproved ? await ethereum.isApproved() : true
+  const aprobable = ethereum._metamask || ethereum
+  return aprobable.isApproved ? await aprobable.isApproved() : true
 }

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -1,9 +1,10 @@
 import { eth, wallets, Contract } from 'decentraland-eth'
 import { isMobile } from '../../lib/utils'
+import { EthereumWindow } from './types'
 
 interface ConnectOptions {
   address: string
-  provider: string
+  provider: object | string
   contracts: Contract[]
   derivationPath?: string
   eth: typeof eth
@@ -48,4 +49,21 @@ function getWallets(
 
 export function isLedgerWallet() {
   return eth.wallet instanceof wallets.LedgerWallet
+}
+
+export function isApprovableWallet() {
+  const { ethereum } = window as EthereumWindow
+  return ethereum !== undefined && typeof ethereum.enable === 'function'
+}
+
+export async function isWalletApproved() {
+  const { ethereum } = window as EthereumWindow
+
+  if (ethereum === undefined) {
+    return false
+  }
+
+  // `isApproved` is not standard. It's supported by MetaMask and it's expected to be implemented by other wallet vendors
+  // but we need to check just in case.
+  return ethereum.isApproved ? await ethereum.isApproved() : true
 }

--- a/src/providers/WalletProvider/WalletProvider.ts
+++ b/src/providers/WalletProvider/WalletProvider.ts
@@ -1,4 +1,8 @@
 import * as React from 'react'
+import {
+  isApprovableWallet,
+  isWalletApproved
+} from '../../modules/wallet/utils'
 import { DefaultProps, Props } from './WalletProvider.types'
 
 export default class WalletProvider extends React.PureComponent<Props> {
@@ -6,9 +10,19 @@ export default class WalletProvider extends React.PureComponent<Props> {
     children: null
   }
 
-  componentWillMount() {
+  async componentWillMount() {
     const { onConnect } = this.props
-    onConnect()
+
+    if (await this.shouldConnect()) {
+      onConnect()
+    }
+  }
+
+  async shouldConnect() {
+    return (
+      !isApprovableWallet() ||
+      (isApprovableWallet() && (await isWalletApproved()))
+    )
   }
 
   render() {


### PR DESCRIPTION
Supports the new standard for Ethereum wallet permissions, where the URL must be approved before being able to access private information.

Release candidate: decentraland-dapps@3.7.0-rc2

Closes: https://github.com/decentraland/marketplace/issues/478 once https://github.com/decentraland/marketplace/pull/597 is merged

To test:
- Follow: https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8 to get the latest metamask version
- Go to the marketplace
  - Checkout https://github.com/decentraland/marketplace/pull/597 if it's not merged
  - Install the release candidate