### PR TITLE
fix: failed transaction watcher

### DIFF
--- a/src/modules/transaction/actions.ts
+++ b/src/modules/transaction/actions.ts
@@ -101,6 +101,17 @@ export type WatchRevertedTransactionAction = ReturnType<
   typeof watchRevertedTransaction
 >
 
+// Fix reverted transaction
+
+export const FIX_REVERTED_TRANSACTION = 'Fix Reverted Transaction'
+
+export const fixRevertedTransaction = (hash: string) =>
+  action(FIX_REVERTED_TRANSACTION, { hash })
+
+export type FixRevertedTransactionAction = ReturnType<
+  typeof fixRevertedTransaction
+>
+
 // Replace transaction
 
 export const REPLACE_TRANSACTION_REQUEST = '[Request] Replace Transaction'

--- a/src/modules/transaction/reducer.ts
+++ b/src/modules/transaction/reducer.ts
@@ -17,7 +17,9 @@ import {
   ClearTransactionsAction,
   ClearTransactionAction,
   CLEAR_TRANSACTIONS,
-  CLEAR_TRANSACTION
+  CLEAR_TRANSACTION,
+  FixRevertedTransactionAction,
+  FIX_REVERTED_TRANSACTION
 } from './actions'
 import { txUtils } from 'decentraland-eth'
 import { isPending } from './utils'
@@ -41,6 +43,7 @@ export type TransactionReducerAction =
   | UpdateTransactionStatusAction
   | UpdateTransactionNonceAction
   | ReplaceTransactionSuccessAction
+  | FixRevertedTransactionAction
   | ClearTransactionsAction
   | ClearTransactionAction
 
@@ -118,6 +121,22 @@ export function transactionReducer(
               ? {
                 ...transaction,
                 status: action.payload.status
+              }
+              : transaction
+        )
+      }
+    }
+    case FIX_REVERTED_TRANSACTION: {
+      return {
+        loading: loadingReducer(state.loading, action),
+        error: null,
+        data: state.data.map(
+          (transaction: Transaction) =>
+            // prettier-ignore
+            action.payload.hash === transaction.hash
+              ? {
+                ...transaction,
+                status: txUtils.TRANSACTION_TYPES.confirmed
               }
               : transaction
         )

--- a/src/modules/transaction/sagas.ts
+++ b/src/modules/transaction/sagas.ts
@@ -289,10 +289,6 @@ function* handleWatchRevertedTransaction(
     getTransaction(state, hash)
   )
 
-  if (txInState.status !== TRANSACTION_TYPES.reverted) {
-    return
-  }
-
   do {
     yield call(delay, txUtils.TRANSACTION_FETCH_DELAY)
     const tx: txUtils.Transaction | null = yield call(() =>

--- a/src/modules/transaction/sagas.ts
+++ b/src/modules/transaction/sagas.ts
@@ -51,7 +51,7 @@ export function* transactionSaga(): IterableIterator<ForkEffect> {
 
 const BLOCKS_DEPTH = 100
 const PENDING_TRANSACTION_THRESHOLD = 72 * 60 * 60 * 1000 // 72 hours
-const REVERTED_TRANSACTION_THRESHOLD = 60 * 60 * 1000 // 1 hour
+const REVERTED_TRANSACTION_THRESHOLD = 24 * 60 * 60 * 1000 // 24 hours
 
 const isExpired = (transaction: Transaction, threshold: number) =>
   Date.now() - transaction.timestamp > threshold

--- a/src/modules/transaction/sagas.ts
+++ b/src/modules/transaction/sagas.ts
@@ -27,7 +27,8 @@ import {
   fetchTransactionRequest,
   watchRevertedTransaction,
   WatchRevertedTransactionAction,
-  WATCH_REVERTED_TRANSACTION
+  WATCH_REVERTED_TRANSACTION,
+  fixRevertedTransaction
 } from './actions'
 import {
   CONNECT_WALLET_SUCCESS,
@@ -295,7 +296,7 @@ function* handleWatchRevertedTransaction(
       txUtils.getTransaction(hash)
     )
     if (tx != null && tx.type === TRANSACTION_TYPES.confirmed) {
-      yield put(updateTransactionStatus(hash, TRANSACTION_TYPES.confirmed))
+      yield put(fixRevertedTransaction(hash))
       return
     }
   } while (!isExpired(txInState, REVERTED_TRANSACTION_THRESHOLD))


### PR DESCRIPTION
This PR fixes a bug that caused the failed transaction watcher to exit on transactions that have just failed. 

This is because by the time the `handleWatchRevertedTransaction` saga kicks in ([here](https://github.com/decentraland/decentraland-dapps/blob/master/src/modules/transaction/sagas.ts#L147)) the state has not been yet updated to mark the transaction as `reverted` ([there](https://github.com/decentraland/decentraland-dapps/blob/master/src/modules/transaction/sagas.ts#L152)). That caused the condition `txInState.status !== TRANSACTION_TYPES.reverted` inside the saga to always evaluate `true`, exiting the saga (so transactions marked as reverted erroneously would not be fixed).

They would still get fixed the next time the user returns to the dapp, because we pick the failed transactions and start a saga for each of them to fix them ([here](https://github.com/decentraland/decentraland-dapps/blob/master/src/modules/transaction/sagas.ts#L312-L324)), but if the user doesn't refresh the dapp before the threshold ([1 hour](https://github.com/decentraland/decentraland-dapps/blob/master/src/modules/transaction/sagas.ts#L54)) those transactions would be left as reverted forever.

I also increased the `REVERTED_TRANSACTION_THRESHOLD` since that value was 1 hour, but it is taken from the time the transaction is inserted in the state, not from the time the transaction failed. Since a transaction can take several minutes (or hours) before it fails, this threshold was to small to let the saga do its job.

Finally I added a separate action to fix the reverted transactions: `fixRevertedTransaction` instead of using `updateTransactionStatus`. This is mostly for monitoring purposes, so we can keep track of failed transactions, dropped transactions, and erroneously marked reverted transactions (by comparing the `WATCH_REVERTED_TRANSACTION` actions against the `FIX_REVERTED_TRANSACTION` ones.