### PR TITLE
feat: added new Navbar, Footer and SignIn containers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
+  "prettier.printWidth": 80,
+  "prettier.singleQuote": true,
+  "prettier.semi": false,
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "0.0.0-development",
+  "version": "4.0.0-rc12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -89,9 +89,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.0.0-beta.56",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.56.tgz",
-      "integrity": "sha512-vP9XV2VP013UEyZdU9eWClCsm6rQPUYHVNCfmpcv5uKviW7mKmUZq71Y5cr5dYsFKfnGDxSo8h6plUGR60lwHg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
+      "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "0.12.1"
@@ -3538,6 +3538,16 @@
         }
       }
     },
+    "@semantic-ui-react/event-stack": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-2.0.0.tgz",
+      "integrity": "sha512-OLw7l+6sXFp7qJQGIpEktqhkQFOKsM8hto4RSkAkqs1NG/rG2Jb7ct8so7x4qaP3UNJEPUfnrFGuCCz3laLIBQ==",
+      "dev": true,
+      "requires": {
+        "exenv": "1.2.2",
+        "prop-types": "15.6.2"
+      }
+    },
     "@types/axios": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.14.0.tgz",
@@ -4148,13 +4158,13 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
       "dev": true
     },
@@ -4557,7 +4567,7 @@
     },
     "babelify": {
       "version": "7.3.0",
-      "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "dev": true,
       "requires": {
@@ -4745,7 +4755,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -5208,7 +5218,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -5221,7 +5231,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -5364,15 +5374,16 @@
       }
     },
     "decentraland-ui": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-1.10.0.tgz",
-      "integrity": "sha512-vdS077R9tnrrGPjVYJpVhkUgEZmdF2NKsnSpGnjrvghVBAxbPBYRxQGY63S1rkbh04RzLSfGEtGmWb2q1yfbFQ==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-1.13.1.tgz",
+      "integrity": "sha512-7KaSwIGlKhCiutbVWD3xX9OsX6C/F2+KLnhCs3iXA1H38CN+OMLh+H2CUXf781X7MdFZXzI8mAR8756TwvAW8Q==",
       "dev": true,
       "requires": {
         "balloon-css": "0.5.0",
         "ethereum-blockies": "0.1.1",
-        "semantic-ui-css": "2.3.3",
-        "semantic-ui-react": "0.81.3"
+        "parallax-js": "3.1.0",
+        "semantic-ui-css": "2.4.1",
+        "semantic-ui-react": "0.82.5"
       }
     },
     "decode-uri-component": {
@@ -6025,6 +6036,12 @@
         "signal-exit": "3.0.2",
         "strip-eof": "1.0.0"
       }
+    },
+    "exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=",
+      "dev": true
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -7374,7 +7391,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
@@ -7476,7 +7493,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -7512,7 +7529,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -7564,7 +7581,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -14250,7 +14267,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -14351,6 +14368,16 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
+    },
+    "parallax-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/parallax-js/-/parallax-js-3.1.0.tgz",
+      "integrity": "sha512-UONoPKSQykeNvFcemDPxYYDU/T89LSffoaZAwOMhDp0ABhmFPwthgn2GrfB7An9Qo+8nPZIuQeZsh2pWn1qN3A==",
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "raf": "3.4.1"
+      }
     },
     "parse-github-url": {
       "version": "1.0.2",
@@ -14638,6 +14665,15 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
+    },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "requires": {
+        "performance-now": "2.1.0"
+      }
     },
     "rc": {
       "version": "1.2.8",
@@ -15394,21 +15430,22 @@
       }
     },
     "semantic-ui-css": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.3.3.tgz",
-      "integrity": "sha512-/UDs+a07LdxmYgVNqkbW9x5Gil1Dt4HnVq4LrHKKUAD/DUDh0fnwmCxbQFyKKD+YsVDQWFqftyVbYKlClBFLDw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/semantic-ui-css/-/semantic-ui-css-2.4.1.tgz",
+      "integrity": "sha512-Pkp0p9oWOxlH0kODx7qFpIRYpK1T4WJOO4lNnpNPOoWKCrYsfHqYSKgk5fHfQtnWnsAKy7nLJMW02bgDWWFZFg==",
       "dev": true,
       "requires": {
         "jquery": "3.3.1"
       }
     },
     "semantic-ui-react": {
-      "version": "0.81.3",
-      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.81.3.tgz",
-      "integrity": "sha512-AGLKjtWT0HnOyduMJn+6T4JmV5DfEuOfN2iSpBmQ5ZNJxrmdD4hoiskP89MUT7JD4Mno7aH8KkzdIKxavxpJUw==",
+      "version": "0.82.5",
+      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-0.82.5.tgz",
+      "integrity": "sha512-Vi7gvo9EbRyNckYd6a/RaY5zk02SFCrRbU9ukdM/OOK8CH7sjIB4f78TkHTUar20Zsw2w6UnFzYWemSvIYfsOQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.0.0-beta.56",
+        "@babel/runtime": "7.1.5",
+        "@semantic-ui-react/event-stack": "2.0.0",
         "classnames": "2.2.6",
         "keyboard-key": "1.0.2",
         "lodash": "4.17.10",
@@ -15476,7 +15513,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -16594,7 +16631,7 @@
     },
     "yargs": {
       "version": "4.8.1",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
       "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "3.8.1-rc3",
+  "version": "0.0.0-development",
   "main": "dist",
   "dependencies": {
     "@types/axios": "^0.14.0",
@@ -39,7 +39,7 @@
     "chai": "^4.1.2",
     "dcl-tslint-config-standard": "^1.0.1",
     "decentraland-eth": "^6.0.0",
-    "decentraland-ui": "^1.8.0",
+    "decentraland-ui": "^1.13.1",
     "husky": "^0.14.3",
     "mocha": "^5.2.0",
     "nyc": "^12.0.2",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "decentraland-eth": ">=6.0.0",
-    "decentraland-ui": "^1.8.0",
+    "decentraland-ui": "^1.13.1",
     "react": "^16.4.1",
     "react-redux": "^5.0.7",
     "react-router-redux": "^5.0.0-alpha.6",

--- a/src/containers/Footer/Footer.container.ts
+++ b/src/containers/Footer/Footer.container.ts
@@ -1,5 +1,6 @@
 import { connect } from 'react-redux'
 import { RouterAction } from 'react-router-redux'
+import { Locale } from 'decentraland-ui'
 
 import Footer from './Footer'
 import { FooterProps, MapDispatchProps, MapStateProps } from './Footer.types'
@@ -10,7 +11,7 @@ import { changeLocale } from '../../modules/translation/actions'
 
 const mapState = (state: any): MapStateProps => {
   return {
-    locale: getLocale(state) as any,
+    locale: getLocale(state),
     hasTranslations: isEnabled(state)
   }
 }
@@ -18,7 +19,7 @@ const mapState = (state: any): MapStateProps => {
 const mapDispatch = (
   dispatch: RootDispatch<RouterAction>
 ): MapDispatchProps => ({
-  onChange: (_, { value }) => dispatch(changeLocale(value as string))
+  onChange: (_, { value }) => dispatch(changeLocale(value as Locale))
 })
 
 const mergeProps = (

--- a/src/containers/Footer/Footer.container.ts
+++ b/src/containers/Footer/Footer.container.ts
@@ -1,0 +1,38 @@
+import { connect } from 'react-redux'
+import { RouterAction } from 'react-router-redux'
+
+import Footer from './Footer'
+import { FooterProps, MapDispatchProps, MapStateProps } from './Footer.types'
+import { RootDispatch } from '../../types'
+import { getLocale } from '../../modules/wallet/selectors'
+import { isEnabled } from '../../modules/translation/selectors'
+import { changeLocale } from '../../modules/translation/actions'
+
+const mapState = (state: any): MapStateProps => {
+  return {
+    locale: getLocale(state) as any,
+    hasTranslations: isEnabled(state)
+  }
+}
+
+const mapDispatch = (
+  dispatch: RootDispatch<RouterAction>
+): MapDispatchProps => ({
+  onChange: (_, { value }) => dispatch(changeLocale(value as string))
+})
+
+const mergeProps = (
+  stateProps: MapStateProps,
+  dispatchProps: MapDispatchProps,
+  ownProps: FooterProps
+): FooterProps => ({
+  ...stateProps,
+  ...dispatchProps,
+  ...ownProps
+})
+
+export default connect(
+  mapState,
+  mapDispatch,
+  mergeProps
+)(Footer) as any

--- a/src/containers/Footer/Footer.tsx
+++ b/src/containers/Footer/Footer.tsx
@@ -29,9 +29,9 @@ export default class Footer extends React.PureComponent<FooterProps> {
     }
   }
 
-  handleChange = (_: any, { value }: any) => {
+  handleChange: FooterProps['onChange'] = (_, { value }) => {
     const { locale, onChange } = this.props
-    if (value != locale && onChange) {
+    if (value && value !== locale && onChange) {
       onChange(_, { value })
     }
   }

--- a/src/containers/Footer/Footer.tsx
+++ b/src/containers/Footer/Footer.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+
+import { Footer as FooterComponent, FooterI18N } from 'decentraland-ui'
+
+import { FooterProps } from './Footer.types'
+import { T } from '../../modules/translation/utils'
+
+export default class Footer extends React.PureComponent<FooterProps> {
+  getTranslations = (): FooterI18N | undefined => {
+    if (!this.props.hasTranslations) {
+      return undefined
+    }
+    return {
+      dropdown: {
+        en: <T id="@dapps.footer.dropdown.en" />,
+        es: <T id="@dapps.footer.dropdown.es" />,
+        fr: <T id="@dapps.footer.dropdown.fr" />,
+        ja: <T id="@dapps.footer.dropdown.ja" />,
+        zh: <T id="@dapps.footer.dropdown.zh" />,
+        ko: <T id="@dapps.footer.dropdown.ko" />
+      },
+      links: {
+        home: <T id="@dapps.footer.links.home" />,
+        privacy: <T id="@dapps.footer.links.privacy" />,
+        terms: <T id="@dapps.footer.links.terms" />,
+        content: <T id="@dapps.footer.links.content" />,
+        ethics: <T id="@dapps.footer.links.ethics" />
+      }
+    }
+  }
+
+  handleChange = (_: any, { value }: any) => {
+    const { locale, onChange } = this.props
+    if (value != locale && onChange) {
+      onChange(_, { value })
+    }
+  }
+
+  render() {
+    return (
+      <FooterComponent
+        {...this.props}
+        onChange={this.handleChange}
+        i18n={this.getTranslations()}
+      />
+    )
+  }
+}

--- a/src/containers/Footer/Footer.types.tsx
+++ b/src/containers/Footer/Footer.types.tsx
@@ -1,0 +1,9 @@
+import { FooterProps as FooterComponentProps } from 'decentraland-ui'
+
+export type FooterProps = FooterComponentProps & {
+  hasTranslations?: boolean
+}
+
+export type MapStateProps = Pick<FooterProps, 'locale' | 'hasTranslations'>
+
+export type MapDispatchProps = Pick<FooterProps, 'onChange'>

--- a/src/containers/Footer/index.ts
+++ b/src/containers/Footer/index.ts
@@ -1,0 +1,2 @@
+import Footer from './Footer.container'
+export default Footer

--- a/src/containers/Navbar/Navbar.container.tsx
+++ b/src/containers/Navbar/Navbar.container.tsx
@@ -1,32 +1,39 @@
 import { connect } from 'react-redux'
-import { goBack, RouterAction } from 'react-router-redux'
-import { Navbar, NavbarProps } from 'decentraland-ui'
-import { RootDispatch } from '../../types'
+import { RouterAction } from 'react-router-redux'
+
+import Navbar from './Navbar'
+import { NavbarProps, MapStateProps, MapDispatchProps } from './Navbar.types'
 import {
   getData as getWallet,
   isConnected,
   isConnecting
 } from '../../modules/wallet/selectors'
+import { isEnabled } from '../../modules/translation/selectors'
+import { connectWalletRequest } from '../../modules/wallet/actions'
+import { RootDispatch } from '../../types'
 
-const mapState = (state: any): NavbarProps => {
+const mapState = (state: any): MapStateProps => {
   const wallet = getWallet(state)
   return {
     mana: wallet.mana,
     address: wallet.address,
     isConnected: isConnected(state),
-    isConnecting: isConnecting(state)
+    isConnecting: isConnecting(state),
+    hasTranslations: isEnabled(state)
   }
 }
 
-const mapDispatch = (dispatch: RootDispatch<RouterAction>) => ({
-  onBack: () => dispatch(goBack())
+const mapDispatch = (
+  dispatch: RootDispatch<RouterAction>
+): MapDispatchProps => ({
+  onSignIn: () => dispatch(connectWalletRequest())
 })
 
 const mergeProps = (
-  stateProps: Partial<NavbarProps>,
-  dispatchProps: Partial<NavbarProps>,
-  ownProps: Partial<NavbarProps>
-) => ({
+  stateProps: MapStateProps,
+  dispatchProps: MapDispatchProps,
+  ownProps: NavbarProps
+): NavbarProps => ({
   ...stateProps,
   ...dispatchProps,
   ...ownProps

--- a/src/containers/Navbar/Navbar.tsx
+++ b/src/containers/Navbar/Navbar.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+
+import { Navbar as NavbarComponent, NavbarI18N } from 'decentraland-ui'
+
+import { NavbarProps } from './Navbar.types'
+import { T } from '../../modules/translation/utils'
+
+export default class Navbar extends React.PureComponent<NavbarProps> {
+  getTranslations = (): NavbarI18N | undefined => {
+    if (!this.props.hasTranslations) {
+      return undefined
+    }
+    return {
+      menu: {
+        marketplace: <T id="@dapps.navbar.menu.marketplace" />,
+        agora: <T id="@dapps.navbar.menu.agora" />,
+        docs: <T id="@dapps.navbar.menu.docs" />,
+        blog: <T id="@dapps.navbar.menu.blog" />
+      },
+      account: {
+        connecting: <T id="@dapps.navbar.account.connecting" />,
+        signIn: <T id="@dapps.navbar.account.signIn" />
+      }
+    }
+  }
+
+  render() {
+    return <NavbarComponent {...this.props} i18n={this.getTranslations()} />
+  }
+}

--- a/src/containers/Navbar/Navbar.types.tsx
+++ b/src/containers/Navbar/Navbar.types.tsx
@@ -1,0 +1,12 @@
+import { NavbarProps as NavbarComponentProps } from 'decentraland-ui'
+
+export type NavbarProps = NavbarComponentProps & {
+  hasTranslations?: boolean
+}
+
+export type MapStateProps = Pick<
+  NavbarProps,
+  'mana' | 'address' | 'isConnected' | 'isConnecting' | 'hasTranslations'
+>
+
+export type MapDispatchProps = Pick<NavbarProps, 'onSignIn'>

--- a/src/containers/SignInPage/SignInPage.container.ts
+++ b/src/containers/SignInPage/SignInPage.container.ts
@@ -1,0 +1,28 @@
+import { connect } from 'react-redux'
+
+import SignInPage from './SignInPage'
+import { MapDispatchProps, MapStateProps } from './SignInPage.types'
+import { RootDispatch } from '../../types'
+import { isEnabled } from '../../modules/translation/selectors'
+import { connectWalletRequest } from '../../modules/wallet/actions'
+import {
+  isConnecting,
+  isConnected,
+  getError
+} from '../../modules/wallet/selectors'
+
+const mapState = (state: any): MapStateProps => ({
+  isConnecting: isConnecting(state),
+  isConnected: isConnected(state),
+  hasError: !!getError(state),
+  hasTranslations: isEnabled(state)
+})
+
+const mapDispatch = (dispatch: RootDispatch): MapDispatchProps => ({
+  onConnect: () => dispatch(connectWalletRequest())
+})
+
+export default connect(
+  mapState,
+  mapDispatch
+)(SignInPage) as any

--- a/src/containers/SignInPage/SignInPage.tsx
+++ b/src/containers/SignInPage/SignInPage.tsx
@@ -1,0 +1,103 @@
+import * as React from 'react'
+
+import { SignIn, SignInI18N } from 'decentraland-ui'
+
+import { SignInPageProps, SignInState } from './SignInPage.types'
+import { T } from '../../modules/translation/utils'
+import { isMobile } from '../../lib/utils'
+
+export default class SignInPage extends React.PureComponent<
+  SignInPageProps,
+  SignInState
+> {
+  constructor(props: SignInPageProps) {
+    super(props)
+    this.state = {
+      hasError: false
+    }
+  }
+
+  componentWillReceiveProps(nextProps: SignInPageProps) {
+    if (nextProps.hasError && !this.state.hasError) {
+      this.setState({
+        hasError: true
+      })
+    } else if (!nextProps.hasError && this.state.hasError) {
+      this.setState({
+        hasError: false
+      })
+    }
+  }
+
+  getTranslations = (): SignInI18N | undefined => {
+    if (!this.props.hasTranslations) {
+      return undefined
+    }
+    return {
+      header: <T id="@dapps.sign_in.get_started" />,
+      error: <T id="@dapps.sign_in.error" />,
+      connect: <T id="@dapps.sign_in.connect" />,
+      connecting: <T id="@dapps.sign_in.connecting" />,
+      connected: <T id="@dapps.sign_in.connected" />,
+      message: isMobile() ? (
+        <T
+          id="@dapps.sign_in.options.mobile"
+          values={{
+            coinbase_link: (
+              <a
+                href="https://wallet.coinbase.com"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Coinbase Wallet
+              </a>
+            ),
+            imtoken_link: (
+              <a
+                href="https://token.im"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                imToken
+              </a>
+            )
+          }}
+        />
+      ) : (
+        <T
+          id="@dapps.sign_in.options.desktop"
+          values={{
+            metamask_link: (
+              <a
+                href="https://metamask.io"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                MetaMask
+              </a>
+            ),
+            ledger_nano_link: (
+              <a
+                href="https://www.ledger.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Ledger Nano S
+              </a>
+            )
+          }}
+        />
+      )
+    }
+  }
+
+  render() {
+    return (
+      <SignIn
+        {...this.props}
+        hasError={this.state.hasError}
+        i18n={this.getTranslations()}
+      />
+    )
+  }
+}

--- a/src/containers/SignInPage/SignInPage.types.ts
+++ b/src/containers/SignInPage/SignInPage.types.ts
@@ -1,0 +1,16 @@
+import { SignInProps } from 'decentraland-ui'
+
+export type SignInPageProps = SignInProps & {
+  hasTranslations?: boolean
+}
+
+export type SignInState = {
+  hasError: boolean
+}
+
+export type MapStateProps = Pick<
+  SignInPageProps,
+  'isConnecting' | 'isConnected' | 'hasError' | 'hasTranslations'
+>
+
+export type MapDispatchProps = Pick<SignInPageProps, 'onConnect'>

--- a/src/containers/SignInPage/index.ts
+++ b/src/containers/SignInPage/index.ts
@@ -1,0 +1,2 @@
+import SignInPage from './SignInPage.container'
+export default SignInPage

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -1,0 +1,4 @@
+export { default as EtherscanLink } from './EtherscanLink'
+export { default as Footer } from './Footer'
+export { default as Navbar } from './Navbar'
+export { default as SignInPage } from './SignInPage'

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,29 +60,3 @@ export function formatDateTime(
 export function formatNumber(amount: number = 0, digits: number = 2) {
   return parseFloat((+amount).toFixed(digits)).toLocaleString()
 }
-
-/**
- * Merges deeply all the properties from one or more source objects into a target object. It will return a new object.
- * @param {object} target The target object
- * @param {...object} sources The source object(s)
- */
-export function merge<T extends Object>(
-  target: T = {} as T,
-  ...sources: (T | undefined)[]
-) {
-  return [target, ...sources].reduce<T>(
-    (result, obj) => _merge<T>(result, obj),
-    {} as T
-  )
-}
-
-function _merge<T extends Object>(target: T = {} as T, source: T = {} as T) {
-  const merged: T = Object.keys(source).reduce((result: T, key: string) => {
-    result[key] =
-      typeof source[key] === 'object'
-        ? _merge(target[key], source[key])
-        : source[key]
-    return result
-  }, target)
-  return merged
-}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,3 +60,29 @@ export function formatDateTime(
 export function formatNumber(amount: number = 0, digits: number = 2) {
   return parseFloat((+amount).toFixed(digits)).toLocaleString()
 }
+
+/**
+ * Merges deeply all the properties from one or more source objects into a target object. It will return a new object.
+ * @param {object} target The target object
+ * @param {...object} sources The source object(s)
+ */
+export function merge<T extends Object>(
+  target: T = {} as T,
+  ...sources: (T | undefined)[]
+) {
+  return [target, ...sources].reduce<T>(
+    (result, obj) => _merge<T>(result, obj),
+    {} as T
+  )
+}
+
+function _merge<T extends Object>(target: T = {} as T, source: T = {} as T) {
+  const merged: T = Object.keys(source).reduce((result: T, key: string) => {
+    result[key] =
+      typeof source[key] === 'object'
+        ? _merge(target[key], source[key])
+        : source[key]
+    return result
+  }, target)
+  return merged
+}

--- a/src/modules/translation/actions.ts
+++ b/src/modules/translation/actions.ts
@@ -1,4 +1,5 @@
 import { action } from 'typesafe-actions'
+import { Locale } from 'decentraland-ui'
 import { TranslationKeys } from './types'
 
 // Fetch translations
@@ -7,10 +8,10 @@ export const FETCH_TRANSLATIONS_REQUEST = '[Request] Fetch Translations'
 export const FETCH_TRANSLATIONS_SUCCESS = '[Success] Fetch Translations'
 export const FETCH_TRANSLATIONS_FAILURE = '[Failure] Fetch Translations'
 
-export const fetchTranslationsRequest = (locale: string) =>
+export const fetchTranslationsRequest = (locale: Locale) =>
   action(FETCH_TRANSLATIONS_REQUEST, { locale })
 export const fetchTranslationsSuccess = (
-  locale: string,
+  locale: Locale,
   translations: TranslationKeys
 ) => action(FETCH_TRANSLATIONS_SUCCESS, { locale, translations })
 export const fetchTranslationsFailure = (error: string) =>
@@ -30,7 +31,7 @@ export type FetchTranslationsFailureAction = ReturnType<
 
 export const CHANGE_LOCALE = 'Change locale'
 
-export const changeLocale = (locale: string) =>
+export const changeLocale = (locale: Locale) =>
   action(CHANGE_LOCALE, { locale })
 
 export type ChangeLocaleAction = ReturnType<typeof changeLocale>

--- a/src/modules/translation/defaults/en.json
+++ b/src/modules/translation/defaults/en.json
@@ -1,0 +1,44 @@
+{
+  "@dapps": {
+    "footer": {
+      "dropdown": {
+        "en": "English",
+        "es": "Spanish",
+        "fr": "French",
+        "ja": "Japanese",
+        "ko": "Korean",
+        "zh": "Chinese"
+      },
+      "links": {
+        "content": "Content Policy",
+        "ethics": "Code of Ethics",
+        "home": "Home",
+        "privacy": "Privacy Policy",
+        "terms": "Terms of Use"
+      }
+    },
+    "navbar": {
+      "account": {
+        "connecting": "Connecting...",
+        "signIn": "Sign In"
+      },
+      "menu": {
+        "agora": "Agora",
+        "blog": "Blog",
+        "docs": "Docs",
+        "marketplace": "Marketplace"
+      }
+    },
+    "sign_in": {
+      "connect": "Connect",
+      "connected": "Connected",
+      "connecting": "Connecting...",
+      "error": "Could not connect to wallet.",
+      "get_started": "Get Started",
+      "options": {
+        "desktop": "You can use the {metamask_link} extension or a hardware wallet like {ledger_nano_link}.",
+        "mobile": "You can use mobile browsers such as {coinbase_link} or {imtoken_link}."
+      }
+    }
+  }
+}

--- a/src/modules/translation/defaults/es.json
+++ b/src/modules/translation/defaults/es.json
@@ -11,7 +11,7 @@
       },
       "links": {
         "content": "Política de contenido",
-        "ethics": "Código de Ético",
+        "ethics": "Código de Ética",
         "home": "Inicio",
         "privacy": "Política de privacidad",
         "terms": "Términos de Uso"

--- a/src/modules/translation/defaults/es.json
+++ b/src/modules/translation/defaults/es.json
@@ -11,7 +11,7 @@
       },
       "links": {
         "content": "Política de contenido",
-        "ethics": "Código ético",
+        "ethics": "Código de Ético",
         "home": "Inicio",
         "privacy": "Política de privacidad",
         "terms": "Términos de Uso"

--- a/src/modules/translation/defaults/es.json
+++ b/src/modules/translation/defaults/es.json
@@ -1,0 +1,44 @@
+{
+  "@dapps": {
+    "footer": {
+      "dropdown": {
+        "en": "Inglés",
+        "es": "Español",
+        "fr": "Francés",
+        "ja": "Japonés",
+        "ko": "Coreano",
+        "zh": "Chino"
+      },
+      "links": {
+        "content": "Política de contenido",
+        "ethics": "Código ético",
+        "home": "Inicio",
+        "privacy": "Política de privacidad",
+        "terms": "Términos de Uso"
+      }
+    },
+    "navbar": {
+      "account": {
+        "connecting": "Conectando...",
+        "signIn": "Conectar"
+      },
+      "menu": {
+        "agora": "Agora",
+        "blog": "Blog",
+        "docs": "Docs",
+        "marketplace": "Marketplace"
+      }
+    },
+    "sign_in": {
+      "connect": "Conectar",
+      "connected": "Conectado",
+      "connecting": "Conectando...",
+      "error": "No se pudo conectar a la billetera.",
+      "get_started": "Comenzar",
+      "options": {
+        "desktop": "Puedes usar la extensión {metamask_link} o una billetera de hardware como {ledger_nano_link}.",
+        "mobile": "Puedes utilizar navegadores móviles como {coinbase_link} o {imtoken_link}."
+      }
+    }
+  }
+}

--- a/src/modules/translation/defaults/fr.json
+++ b/src/modules/translation/defaults/fr.json
@@ -1,0 +1,44 @@
+{
+  "@dapps": {
+    "footer": {
+      "dropdown": {
+        "en": "Anglais",
+        "es": "Espanol",
+        "fr": "Français",
+        "ja": "Japonais",
+        "ko": "Coréen",
+        "zh": "Chinois"
+      },
+      "links": {
+        "content": "Contenu",
+        "ethics": "Code d'éthique",
+        "home": "Accueil",
+        "privacy": "Confidentialité",
+        "terms": "Conditions d'utilisation"
+      }
+    },
+    "navbar": {
+      "account": {
+        "connecting": "De liaison...",
+        "signIn": "Se connecter"
+      },
+      "menu": {
+        "agora": "Agora",
+        "blog": "Blog",
+        "docs": "Docs",
+        "marketplace": "Marketplace"
+      }
+    },
+    "sign_in": {
+      "connect": "Relier",
+      "connected": "Connecté",
+      "connecting": "De liaison...",
+      "error": "Impossible de se connecter au portefeuille.",
+      "get_started": "Commencer",
+      "options": {
+        "desktop": "Vous pouvez utiliser l'extension {metamask_link} ou un portefeuille matériel comme {ledger_nano_link}.",
+        "mobile": "Vous pouvez utiliser des navigateurs mobiles tels que {coinbase_link} ou {imtoken_link}."
+      }
+    }
+  }
+}

--- a/src/modules/translation/defaults/index.ts
+++ b/src/modules/translation/defaults/index.ts
@@ -1,0 +1,8 @@
+import en = require('./en.json')
+import es = require('./es.json')
+import fr = require('./fr.json')
+import ja = require('./ja.json')
+import ko = require('./ko.json')
+import zh = require('./zh.json')
+
+export { en, es, fr, ja, ko, zh }

--- a/src/modules/translation/defaults/ja.json
+++ b/src/modules/translation/defaults/ja.json
@@ -1,0 +1,44 @@
+{
+  "@dapps": {
+    "footer": {
+      "dropdown": {
+        "en": "英語",
+        "es": "スペイン語",
+        "fr": "フランス語",
+        "ja": "日本人",
+        "ko": "韓国語",
+        "zh": "中国語"
+      },
+      "links": {
+        "content": "コンテンツポリシー",
+        "ethics": "倫理規定",
+        "home": "ホーム",
+        "privacy": "個人情報保護方針",
+        "terms": "利用規約"
+      }
+    },
+    "navbar": {
+      "account": {
+        "connecting": "接続中...",
+        "signIn": "サインイン"
+      },
+      "menu": {
+        "agora": "Agora",
+        "blog": "Blog",
+        "docs": "Docs",
+        "marketplace": "Marketplace"
+      }
+    },
+    "sign_in": {
+      "connect": "接続する",
+      "connected": "接続済み",
+      "connecting": "接続中...",
+      "error": "ウォレットに接続できませんでした。",
+      "get_started": "開始する",
+      "options": {
+        "desktop": "{metamask_link}拡張や{ledger_nano_link}のようなハードウェア・ウォレットを使用できます。",
+        "mobile": "{coinbase_link}や{imtoken_link}などのモバイルブラウザを使用できます。"
+      }
+    }
+  }
+}

--- a/src/modules/translation/defaults/ko.json
+++ b/src/modules/translation/defaults/ko.json
@@ -1,0 +1,44 @@
+{
+  "@dapps": {
+    "footer": {
+      "dropdown": {
+        "en": "영어",
+        "es": "스페인 사람",
+        "fr": "프랑스 국민",
+        "ja": "일본어",
+        "ko": "한국어",
+        "zh": "중국말"
+      },
+      "links": {
+        "content": "콘텐츠 정책",
+        "ethics": "윤리 강령",
+        "home": "집",
+        "privacy": "개인 정보 정책",
+        "terms": "이용 약관"
+      }
+    },
+    "navbar": {
+      "account": {
+        "connecting": "연결 중 ...",
+        "signIn": "로그인"
+      },
+      "menu": {
+        "agora": "Agora",
+        "blog": "Blog",
+        "docs": "Docs",
+        "marketplace": "Marketplace"
+      }
+    },
+    "sign_in": {
+      "connect": "잇다",
+      "connected": "연결됨",
+      "connecting": "연결 중 ...",
+      "error": "지갑에 연결할 수 없습니다.",
+      "get_started": "시작하다",
+      "options": {
+        "desktop": "{metamask_link} 확장 또는 {ledger_nano_link}과 같은 하드웨어 지갑을 사용할 수 있습니다.",
+        "mobile": "{coinbase_link} 또는 {imtoken_link}과 같은 모바일 브라우저를 사용할 수 있습니다."
+      }
+    }
+  }
+}

--- a/src/modules/translation/defaults/zh.json
+++ b/src/modules/translation/defaults/zh.json
@@ -1,0 +1,44 @@
+{
+  "@dapps": {
+    "footer": {
+      "dropdown": {
+        "en": "英语",
+        "es": "西班牙语",
+        "fr": "法国",
+        "ja": "日本",
+        "ko": "朝鲜的",
+        "zh": "中文"
+      },
+      "links": {
+        "content": "内容政策",
+        "ethics": "道德准则",
+        "home": "家",
+        "privacy": "隐私政策",
+        "terms": "使用条款"
+      }
+    },
+    "navbar": {
+      "account": {
+        "connecting": "连接...",
+        "signIn": "登入"
+      },
+      "menu": {
+        "agora": "Agora",
+        "blog": "Blog",
+        "docs": "Docs",
+        "marketplace": "Marketplace"
+      }
+    },
+    "sign_in": {
+      "connect": "连",
+      "connected": "连接的",
+      "connecting": "连接...",
+      "error": "无法连接到钱包。",
+      "get_started": "入门",
+      "options": {
+        "desktop": "您可以使用{metamask_link}扩展名或硬件钱包，如{ledger_nano_link}。",
+        "mobile": "您可以使用移动浏览器，例如{coinbase_link}或{imtoken_link}。"
+      }
+    }
+  }
+}

--- a/src/modules/translation/sagas.ts
+++ b/src/modules/translation/sagas.ts
@@ -7,9 +7,8 @@ import {
   FETCH_TRANSLATIONS_REQUEST,
   FetchTranslationsRequestAction
 } from './actions'
-import { setCurrentLocale } from './utils'
+import { setCurrentLocale, mergeTranslations } from './utils'
 import * as defaultTranslations from './defaults'
-import { merge } from '../../lib/utils'
 
 export type TranslationSagaOptions = {
   getTranslation?: (locale: string) => Promise<Translation>
@@ -39,7 +38,7 @@ export function createTranslationSaga({
       setCurrentLocale(locale)
 
       // merge translations and defaults
-      result = merge<TranslationKeys>(
+      result = mergeTranslations<TranslationKeys>(
         flatten(defaultTranslations[locale]),
         result
       )

--- a/src/modules/translation/sagas.ts
+++ b/src/modules/translation/sagas.ts
@@ -1,6 +1,6 @@
 import { takeEvery, put, call, ForkEffect } from 'redux-saga/effects'
 import * as flatten from 'flat'
-import { Translation } from './types'
+import { Translation, TranslationKeys } from './types'
 import {
   fetchTranslationsSuccess,
   fetchTranslationsFailure,
@@ -8,6 +8,8 @@ import {
   FetchTranslationsRequestAction
 } from './actions'
 import { setCurrentLocale } from './utils'
+import * as defaultTranslations from './defaults'
+import { merge } from '../../lib/utils'
 
 export type TranslationSagaOptions = {
   getTranslation?: (locale: string) => Promise<Translation>
@@ -35,6 +37,12 @@ export function createTranslationSaga({
       }
 
       setCurrentLocale(locale)
+
+      // merge translations and defaults
+      result = merge<TranslationKeys>(
+        flatten(defaultTranslations[locale]),
+        result
+      )
 
       yield put(fetchTranslationsSuccess(locale, result))
     } catch (error) {

--- a/src/modules/translation/selectors.ts
+++ b/src/modules/translation/selectors.ts
@@ -8,3 +8,5 @@ export const getLoading: (state: any) => TranslationState['loading'] = state =>
   getState(state).loading
 export const isLoading: (state: any) => boolean = state =>
   getLoading(state).length > 0
+
+export const isEnabled: (state: any) => boolean = state => !!getState(state)

--- a/src/modules/translation/utils.ts
+++ b/src/modules/translation/utils.ts
@@ -84,3 +84,27 @@ export function t(id: string, values?: any) {
 }
 
 export const T = FormattedMessage
+
+export function mergeTranslations<T extends { [key: string]: T | string }>(
+  target: T = {} as T,
+  ...sources: (T | undefined)[]
+) {
+  return [target, ...sources].reduce<T>(
+    (result, obj) => _mergeTranslations<T>(result, obj),
+    {} as T
+  )
+}
+
+function _mergeTranslations<T extends { [key: string]: T | string }>(
+  target: T = {} as T,
+  source: T = {} as T
+) {
+  const merged: T = Object.keys(source).reduce((result: T, key: string) => {
+    result[key] =
+      typeof source[key] === 'object'
+        ? _mergeTranslations(target[key] as T, source[key] as T)
+        : source[key]
+    return result
+  }, target)
+  return merged
+}

--- a/src/modules/translation/utils.ts
+++ b/src/modules/translation/utils.ts
@@ -5,6 +5,8 @@ import {
   FormattedMessage
 } from 'react-intl'
 
+import { Locale } from 'decentraland-ui'
+
 import * as enIntlData from 'react-intl/locale-data/en'
 import * as esIntlData from 'react-intl/locale-data/es'
 import * as frIntlData from 'react-intl/locale-data/fr'
@@ -42,14 +44,14 @@ export function addAvailableLocaleData(): void {
 }
 
 export function getPreferredLocale(
-  availableLocales: string[] = ['en']
-): string {
+  availableLocales: Locale[] = ['en']
+): Locale {
   const navigator = window.navigator
 
-  let locale =
+  const navigatorLocale =
     (navigator.languages && navigator.languages[0]) || navigator.language
 
-  locale = locale.slice(0, 2)
+  let locale: Locale = navigatorLocale.slice(0, 2) as Locale
 
   if (!availableLocales.includes(locale)) {
     locale = DEFAULT_LOCALE
@@ -62,7 +64,7 @@ export function setI18n(intl: InjectedIntl) {
   i18n = intl
 }
 
-export function setCurrentLocale(localeName: string) {
+export function setCurrentLocale(localeName: Locale) {
   currentLocale = {
     en: enFnsData,
     es: esFnsData,

--- a/src/modules/wallet/types.ts
+++ b/src/modules/wallet/types.ts
@@ -1,4 +1,5 @@
 import { contracts } from 'decentraland-eth'
+import { Locale } from 'decentraland-ui'
 
 export type BigNumber = {
   toString(): string
@@ -14,7 +15,7 @@ export interface BaseWallet {
   network: string
   address: string
   mana: number
-  locale?: string
+  locale?: Locale
   derivationPath?: string
 }
 

--- a/src/providers/TranslationProvider/TranslationProvider.container.ts
+++ b/src/providers/TranslationProvider/TranslationProvider.container.ts
@@ -1,31 +1,39 @@
 import { connect } from 'react-redux'
+
+import { Locale } from 'decentraland-ui'
+
+import TranslationProvider from './TranslationProvider'
+import { MapStateProps, MapDispatchProps } from './TranslationProvider.types'
 import { getLocale } from '../../modules/wallet/selectors'
 import { isLoading } from '../../modules/storage/selectors'
 import { getData } from '../../modules/translation/selectors'
 import { fetchTranslationsRequest } from '../../modules/translation/actions'
 import { getPreferredLocale } from '../../modules/translation/utils'
 import { RootDispatch } from '../../types'
-import { MapStateProps, MapDispatchProps } from './TranslationProvider.types'
-import TranslationProvider from './TranslationProvider'
 
 const mapState = (state: any): MapStateProps => {
   // Wait until the locale is loaded from the storage to select it
-  let locale = isLoading(state) ? '' : getLocale(state) || getPreferredLocale()
+  let locale
   let translations
 
-  const translationsInState = getData(state)[locale]
-  if (translationsInState) {
-    translations = translationsInState
+  if (!isLoading(state)) {
+    locale = getLocale(state) || getPreferredLocale()
+    if (locale) {
+      const translationsInState = getData(state)[locale]
+      if (translationsInState) {
+        translations = translationsInState
+      }
+    }
   }
 
   return {
-    locale,
+    locale: locale as Locale,
     translations
   }
 }
 
 const mapDispatch = (dispatch: RootDispatch): MapDispatchProps => ({
-  onFetchTranslations: (locale: string) =>
+  onFetchTranslations: (locale: Locale) =>
     dispatch(fetchTranslationsRequest(locale))
 })
 

--- a/src/providers/TranslationProvider/TranslationProvider.tsx
+++ b/src/providers/TranslationProvider/TranslationProvider.tsx
@@ -16,7 +16,7 @@ export default class TranslationProvider extends React.PureComponent<Props> {
   componentWillReceiveProps(nextProps: Props) {
     const { locale, onFetchTranslations } = nextProps
 
-    if (this.props.locale !== locale) {
+    if (locale && this.props.locale !== locale) {
       onFetchTranslations(locale)
     }
   }

--- a/src/providers/TranslationProvider/TranslationProvider.types.ts
+++ b/src/providers/TranslationProvider/TranslationProvider.types.ts
@@ -1,9 +1,11 @@
+import { Locale } from 'decentraland-ui'
+
 import { fetchTranslationsRequest } from '../../modules/translation/actions'
 import { TranslationKeys } from '../../modules/translation/types'
 
 export interface Props {
-  locale: string
-  locales: string[]
+  locale?: Locale
+  locales: Locale[]
   translations?: TranslationKeys
   children?: React.ReactNode
   onFetchTranslations: typeof fetchTranslationsRequest

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "plugins": [{ "name": "tslint-language-service" }],
-    "declaration": true
+    "declaration": true,
+    "resolveJsonModule": true
   },
   "exclude": [
     "node_modules",

--- a/tslint.json
+++ b/tslint.json
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "dcl-tslint-config-standard",
-    "tslint-plugin-prettier"
-  ],
+  "extends": ["dcl-tslint-config-standard", "tslint-plugin-prettier"],
   "rules": {
     "no-commented-out-code": false,
     "jsx-no-multiline-js": false,


### PR DESCRIPTION
This PR adds support for the new Navbar, and also de Footer and SignIn containers.

The containers can be used with or without translation module. If used with translation module, they already come with translations for the 6 supported languages, but the user can override any translation by providing it along with their dapps translations, under the namespace `@dapps`. 

For example you can change the english translation for the Marketplace button in the navbar by adding the following to the dapp's `en.json`:

```
{
  ...
  "@dapps": {
    "navbar": {
      "menu": {
        "marketplace": "Pepe"
      }
    }
  }
}
```