### PR TITLE
feat: location

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ Common modules for our dApps
 - [Lib](https://github.com/decentraland/decentraland-dapps#lib)
   - [API](https://github.com/decentraland/decentraland-dapps#api)
 - [Containers](https://github.com/decentraland/decentraland-dapps#lib)
+  - [App](https://github.com/decentraland/decentraland-dapps#app)
   - [Navbar](https://github.com/decentraland/decentraland-dapps#navbar)
+  - [Footer](https://github.com/decentraland/decentraland-dapps#footer)
+  - [SignInPage](https://github.com/decentraland/decentraland-dapps#signinpage)
   - [EtherscanLink](https://github.com/decentraland/decentraland-dapps#etherscanlink)
 
 # Modules
@@ -929,17 +932,33 @@ Also, all the pending actions are stored in an array in `state.invite.loading` s
 
 ## Location
 
-The location module provides a `navigateTo` action that wrapps `react-router-redux`'s `push` action. It also provides some helpful selectors:
+The location module provides a `navigateTo`, `navigateToSignIn` and `navigateToRoot` actions that wrapps `react-router-redux`'s `push` action. It also provides some helpful selectors:
 
 ```ts
 getLocation(state)
 getPathname(state)
 getPathAction(state) // returns the final part of a url (after the last slash)
+isSignIn(state)
+isRoot(state)
 ```
 
 ### Installation
 
-You need to add a saga to use this module
+You need to add a reducer and a saga to use this module
+
+**Reducer**:
+
+Add the `translationReducer` as `translation` to your `rootReducer`:
+
+```ts
+import { combineReducers } from 'redux'
+import { locationReducer as location } from 'decentraland-dapps/dist/modules/location/reducer'
+
+export const rootReducer = combineReducers({
+  location
+  // your other reducers
+})
+```
 
 **Saga**:
 
@@ -954,6 +973,33 @@ export function* rootSaga() {
   ])
 }
 ```
+
+### Advanced Usage
+
+You can use different paths for default locations by creating a location reducer
+
+<details><summary>Learn More</summary>
+<p>
+
+```ts
+import { combineReducers } from 'redux'
+import { createLocationReducer } from 'decentraland-dapps/dist/modules/location/reducer'
+
+const locationReducer = createLocationReducer({
+  root: '/',
+  signIn: '/sign-in'
+})
+
+export const rootReducer = combineReducers({
+  location
+  // your other reducers
+})
+```
+
+This way you can change the default locations to use different ones. This will be used by the selectors like `isSignIn` and `isRoot`. which impacts the behaviour of several containers like `Navbar` and `SignInPage`
+
+</p>
+</details>
 
 # Lib
 
@@ -990,7 +1036,7 @@ The `<Navbar>` container can be used in the same way as the `<Navbar>` component
 
 ### Dependencies
 
-This container requires you to install the [Wallet](https://github.com/decentraland/decentraland-dapps#wallet) module
+This container requires you to install the [Wallet](https://github.com/decentraland/decentraland-dapps#wallet) and the [Location](https://github.com/decentraland/decentraland-dapps#location) modules
 
 ### Usage
 
@@ -1025,6 +1071,275 @@ export default class Page extends React.PureComponent {
 ```
 
 This `<Navbar>` will show the user's blockie and mana balance because it is connected to the store.
+
+## Navbar
+
+The `<Navbar>` container can be used in the same way as the `<Navbar>` component from `decentaland-ui` but it's already connected to the redux store. You can override any `NavbarProp` if you want to connect differently, and you can pass all the regular `NavbarProps` to it.
+
+### Dependencies
+
+This container requires you to install the [Wallet](https://github.com/decentraland/decentraland-dapps#wallet) and the [Location](https://github.com/decentraland/decentraland-dapps#location) modules. It also has support for i18n out of the box if you include the [Translation](https://github.com/decentraland/decentraland-dapps#translation) module.
+
+### Usage
+
+This is an example of a `SomePage` component that uses the `<Navbar>` container:
+
+```tsx
+import * as React from 'react'
+
+import { Container } from 'decentraland-ui'
+import Navbar from 'decentraland-dapps/dist/containers/Navbar'
+
+import './SomePage.css'
+
+export default class SomePage extends React.PureComponent {
+  static defaultProps = {
+    children: null
+  }
+
+  render() {
+    const { children } = this.props
+
+    return (
+      <>
+        <div className="SomePage">
+          <Container>{children}</Container>
+        </div>
+        <Navbar />
+      </>
+    )
+  }
+}
+```
+
+This `<Navbar>` will show the user's blockie and mana balance because it is connected to the store.
+
+### i18n
+
+If you are using the [Translation](https://github.com/decentraland/decentraland-dapps#translation) module, the `Navbar` contatiner comes with support for the 6 languages supported by the library.
+
+### Advanced Usage
+
+You can override any of the default translations for any locale if you need to
+
+<details><summary>Learn More</summary>
+<p>
+
+Say you want to override some translations in English, just include any or all of the following translations in your `en.json` locale file:
+
+```json
+{
+  "@dapps": {
+    "navbar": {
+      "account": {
+        "connecting": "Connecting...",
+        "signIn": "Sign In"
+      },
+      "menu": {
+        "agora": "Agora",
+        "blog": "Blog",
+        "docs": "Docs",
+        "marketplace": "Marketplace"
+      }
+    }
+  }
+}
+```
+
+## Footer
+
+The `<Footer>` container can be used in the same way as the `<Footer>` component from `decentaland-ui` but it's already connected to the redux store. You can override any `FooterProps` if you want to connect differently, and you can pass all the regular `FooterProps` to it.
+
+### Dependencies
+
+The `<Footer>` container has support for i18n out of the box if you include the [Translation](https://github.com/decentraland/decentraland-dapps#translation) module.
+
+### Usage
+
+This is an example of a `SomePage` component that uses the `<Footer>` container:
+
+```tsx
+import * as React from 'react'
+
+import { Container } from 'decentraland-ui'
+import Navbar from 'decentraland-dapps/dist/containers/Navbar'
+
+import './SomePage.css'
+
+export default class SomePage extends React.PureComponent {
+  render() {
+    const { children } = this.props
+    return (
+      <>
+        <div className="SomePage">
+          <Container>{children}</Container>
+        </div>
+        <Footer locales={['en', 'es']} />
+      </>
+    )
+  }
+}
+```
+
+This `<Footer>` will show all only English and Spanish as the options in the language dropdown. If you don't provide any it will use the 6 supported languages: `en`, `es`, `fr`, `jp`, `ko` and `zh`.
+
+### i18n
+
+If you are using the [Translation](https://github.com/decentraland/decentraland-dapps#translation) module, the `Footer` contatiner comes with support for the 6 languages supported by the library.
+
+### Advanced Usage
+
+You can override any of the default translations for any locale if you need to
+
+<details><summary>Learn More</summary>
+<p>
+
+Say you want to override some translations in English, just include any or all of the following translations in your `en.json` locale file:
+
+```json
+{
+  "@dapps": {
+    "footer": {
+      "dropdown": {
+        "en": "English",
+        "es": "Spanish",
+        "fr": "French",
+        "ja": "Japanese",
+        "ko": "Korean",
+        "zh": "Chinese"
+      },
+      "links": {
+        "content": "Content Policy",
+        "ethics": "Code of Ethics",
+        "home": "Home",
+        "privacy": "Privacy Policy",
+        "terms": "Terms of Use"
+      }
+    }
+  }
+}
+```
+
+## SignInPage
+
+The `<SignInPage>` container can be used in the same way as the `<SignIn>` component from `decentaland-ui` but it's already connected to the redux store. You can override any `SignInProp` if you want to connect differently, and you can pass all the regular `SignInProps` to it.
+
+### Dependencies
+
+This container requires you to install the [Wallet](https://github.com/decentraland/decentraland-dapps#wallet) and the [Location](https://github.com/decentraland/decentraland-dapps#location) modules. It also has support for i18n out of the box if you include the [Translation](https://github.com/decentraland/decentraland-dapps#translation) module.
+
+### Usage
+
+You can import the `<SignInPage>` container and use it on your routes:
+
+```tsx
+import * as React from 'react'
+import { Switch, Route } from 'react-router-dom'
+
+import SignInPage from 'decentraland-dapps/dist/containers/SignInPage'
+
+//...
+
+<Switch>
+  <Route exact path='/' component={...} />
+  {/* your dapps routes... */}
+  <Route exact path='/sign-in' component={SignInPage} />
+</Switch>
+```
+
+### i18n
+
+If you are using the [Translation](https://github.com/decentraland/decentraland-dapps#translation) module, the `SignInPage` contatiner comes with support for the 6 languages supported by the library.
+
+### Advanced Usage
+
+You can override any of the default translations for any locale if you need to
+
+<details><summary>Learn More</summary>
+<p>
+
+Say you want to override some translations in English, just include any or all of the following translations in your `en.json` locale file:
+
+```json
+{
+  "@dapps": {
+    "sign_in": {
+      "connect": "Connect",
+      "connected": "Connected",
+      "connecting": "Connecting...",
+      "error": "Could not connect to wallet.",
+      "get_started": "Get Started",
+      "options": {
+        "desktop": "You can use the {metamask_link} extension or a hardware wallet like {ledger_nano_link}.",
+        "mobile": "You can use mobile browsers such as {coinbase_link} or {imtoken_link}."
+      }
+    }
+  }
+}
+```
+
+## App
+
+The `<App>` container is the easiest way to bootstrap your dApp. Internally it will use a `<Navbar>`, `<Page>` and `<Footer>` components, and connect them all to the redux store. It takes all the props from `NavbarProps`, `PageProps` and `FooterProps` and if you provide any of them it will override the connected props.
+
+It also has a `hero` and a `heroHeight` props that can be used to easily include a hero for the homepage (optional).
+
+### Dependencies
+
+This container requires you to install the [Wallet](https://github.com/decentraland/decentraland-dapps#wallet) and the [Location](https://github.com/decentraland/decentraland-dapps#location) modules. It also has support for i18n out of the box if you include the [Translation](https://github.com/decentraland/decentraland-dapps#translation) module.
+
+### Usage
+
+You just need to use the `<App>` component to wrapp your dApp:
+
+```tsx
+import App from 'decentraland-dapps/dist/containers/App'
+
+export default class MyApp extends React.Component {
+  render() {
+    return <App>{/* your dApp here */}</App>
+  }
+}
+```
+
+You can pass any `NavbarProps`, `FooterProps` or `PageProps` and they will be passed down to the corresponding component:
+
+```tsx
+import App from 'decentraland-dapps/dist/containers/App'
+
+export default class MyApp extends React.Component {
+  render() {
+    return (
+      <App activePage="marketplace" locales={['en', 'es']}>
+        {/* your dApp here */}
+      </App>
+    )
+  }
+}
+```
+
+You can also pass a `hero` and it will be used in the homepage, and adjust the height of the hero with the prop `heroHeight` (default height is `302` pixels)
+
+```tsx
+import App from 'decentraland-dapps/dist/containers/App'
+
+import Hero from '../components/Hero'
+
+export default class MyApp extends React.Component {
+  render() {
+    return (
+      <App
+        hero={<Hero />}
+        heroHeight={302}
+        activePage="marketplace"
+        locales={['en', 'es']}
+      >
+        {/* your dApp here */}
+      </App>
+    )
+  }
+}
+```
 
 ## EtherscanLink
 

--- a/README.md
+++ b/README.md
@@ -948,7 +948,7 @@ You need to add a reducer and a saga to use this module
 
 **Reducer**:
 
-Add the `translationReducer` as `translation` to your `rootReducer`:
+Add the `locationReducer` as `location` to your `rootReducer`:
 
 ```ts
 import { combineReducers } from 'redux'
@@ -985,7 +985,7 @@ You can use different paths for default locations by creating a location reducer
 import { combineReducers } from 'redux'
 import { createLocationReducer } from 'decentraland-dapps/dist/modules/location/reducer'
 
-const locationReducer = createLocationReducer({
+const location = createLocationReducer({
   root: '/',
   signIn: '/sign-in'
 })
@@ -1102,10 +1102,10 @@ export default class SomePage extends React.PureComponent {
 
     return (
       <>
+        <Navbar />
         <div className="SomePage">
           <Container>{children}</Container>
         </div>
-        <Navbar />
       </>
     )
   }

--- a/README.md
+++ b/README.md
@@ -1032,49 +1032,7 @@ Common containers for dApps
 
 ## Navbar
 
-The `<Navbar>` container can be used in the same way as the `<Navbar>` component from `decentaland-ui` but it's already connected to the redux store. You can override any `NavbarProp` if you want to connect differently, and you can pass all the regular `NavbarProps` to it.
-
-### Dependencies
-
-This container requires you to install the [Wallet](https://github.com/decentraland/decentraland-dapps#wallet) and the [Location](https://github.com/decentraland/decentraland-dapps#location) modules
-
-### Usage
-
-This is an example of a `Page` component that uses the `<Navbar>` container:
-
-```tsx
-import * as React from 'react'
-
-import { Container } from 'decentraland-ui'
-import Navbar from 'decentraland-dapps/dist/containers/Navbar'
-
-import './Page.css'
-
-export default class Page extends React.PureComponent {
-  static defaultProps = {
-    children: null
-  }
-
-  render() {
-    const { children } = this.props
-
-    return (
-      <>
-        <Navbar />
-        <div className="Page">
-          <Container>{children}</Container>
-        </div>
-      </>
-    )
-  }
-}
-```
-
-This `<Navbar>` will show the user's blockie and mana balance because it is connected to the store.
-
-## Navbar
-
-The `<Navbar>` container can be used in the same way as the `<Navbar>` component from `decentaland-ui` but it's already connected to the redux store. You can override any `NavbarProp` if you want to connect differently, and you can pass all the regular `NavbarProps` to it.
+The `<Navbar>` container can be used in the same way as the `<Navbar>` component from [decentraland-ui](https://github.com/decentraland/ui) but it's already connected to the redux store. You can override any `NavbarProp` if you want to connect differently, and you can pass all the regular `NavbarProps` to it.
 
 ### Dependencies
 
@@ -1148,7 +1106,7 @@ Say you want to override some translations in English, just include any or all o
 
 ## Footer
 
-The `<Footer>` container can be used in the same way as the `<Footer>` component from `decentaland-ui` but it's already connected to the redux store. You can override any `FooterProps` if you want to connect differently, and you can pass all the regular `FooterProps` to it.
+The `<Footer>` container can be used in the same way as the `<Footer>` component from [decentraland-ui](https://github.com/decentraland/ui) but it's already connected to the redux store. You can override any `FooterProps` if you want to connect differently, and you can pass all the regular `FooterProps` to it.
 
 ### Dependencies
 
@@ -1181,7 +1139,7 @@ export default class SomePage extends React.PureComponent {
 }
 ```
 
-This `<Footer>` will show all only English and Spanish as the options in the language dropdown. If you don't provide any it will use the 6 supported languages: `en`, `es`, `fr`, `jp`, `ko` and `zh`.
+This `<Footer>` will show only English and Spanish as the options in the language dropdown. If you don't provide any it will use the 6 supported languages: `en`, `es`, `fr`, `jp`, `ko` and `zh`.
 
 ### i18n
 
@@ -1222,7 +1180,7 @@ Say you want to override some translations in English, just include any or all o
 
 ## SignInPage
 
-The `<SignInPage>` container can be used in the same way as the `<SignIn>` component from `decentaland-ui` but it's already connected to the redux store. You can override any `SignInProp` if you want to connect differently, and you can pass all the regular `SignInProps` to it.
+The `<SignInPage>` container can be used in the same way as the `<SignIn>` component from [decentraland-ui](https://github.com/decentraland/ui) but it's already connected to the redux store. You can override any `SignInProp` if you want to connect differently, and you can pass all the regular `SignInProps` to it.
 
 ### Dependencies
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "4.0.0-rc12",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -89,9 +89,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.5.tgz",
-      "integrity": "sha512-xKnPpXG/pvK1B90JkwwxSGii90rQGKtzcMt2gI5G6+M0REXaq6rOHsGC2ay6/d0Uje7zzvSzjEzfR3ENhFlrfA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+      "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "0.12.1"
@@ -5374,9 +5374,9 @@
       }
     },
     "decentraland-ui": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-1.13.1.tgz",
-      "integrity": "sha512-7KaSwIGlKhCiutbVWD3xX9OsX6C/F2+KLnhCs3iXA1H38CN+OMLh+H2CUXf781X7MdFZXzI8mAR8756TwvAW8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui/-/decentraland-ui-1.15.0.tgz",
+      "integrity": "sha512-6qW1eCqI56Uydb/6wFT5rspTM+XLj93+eSWva6AROpfU2P/nQ6JdfnquNWJg8B/skGkQ1C40cthlKXT9pJ8R0Q==",
       "dev": true,
       "requires": {
         "balloon-css": "0.5.0",
@@ -15444,7 +15444,7 @@
       "integrity": "sha512-Vi7gvo9EbRyNckYd6a/RaY5zk02SFCrRbU9ukdM/OOK8CH7sjIB4f78TkHTUar20Zsw2w6UnFzYWemSvIYfsOQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "7.1.5",
+        "@babel/runtime": "7.2.0",
         "@semantic-ui-react/event-stack": "2.0.0",
         "classnames": "2.2.6",
         "keyboard-key": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chai": "^4.1.2",
     "dcl-tslint-config-standard": "^1.0.1",
     "decentraland-eth": "^6.0.0",
-    "decentraland-ui": "^1.13.1",
+    "decentraland-ui": "^1.15.0",
     "husky": "^0.14.3",
     "mocha": "^5.2.0",
     "nyc": "^12.0.2",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "decentraland-eth": ">=6.0.0",
-    "decentraland-ui": "^1.13.1",
+    "decentraland-ui": "^1.15.0",
     "react": "^16.4.1",
     "react-redux": "^5.0.7",
     "react-router-redux": "^5.0.0-alpha.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "3.10.0-rc6",
+  "version": "0.0.0-development",
   "main": "dist",
   "dependencies": {
     "@types/axios": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "0.0.0-development",
+  "version": "3.10.0-rc6",
   "main": "dist",
   "dependencies": {
     "@types/axios": "^0.14.0",

--- a/src/containers/App/App.container.tsx
+++ b/src/containers/App/App.container.tsx
@@ -1,0 +1,29 @@
+import { connect } from 'react-redux'
+
+import App from './App'
+import { MapStateProps, AppProps } from './App.types'
+import { isRoot } from '../../modules/location/selectors'
+
+const mapState = (state: any): MapStateProps => {
+  return {
+    isHomePage: isRoot(state)
+  }
+}
+
+const mapDispatch = () => ({})
+
+const mergeProps = (
+  stateProps: MapStateProps,
+  dispatchProps: object,
+  ownProps: AppProps
+) => ({
+  ...stateProps,
+  ...dispatchProps,
+  ...ownProps
+})
+
+export default connect(
+  mapState,
+  mapDispatch,
+  mergeProps
+)(App) as any

--- a/src/containers/App/App.tsx
+++ b/src/containers/App/App.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+
+import { Page, NavbarProps, PageProps, FooterProps } from 'decentraland-ui'
+
+import Navbar from '../Navbar'
+import Footer from '../Footer'
+import { AppProps } from './App.types'
+
+export default class App extends React.PureComponent<
+  AppProps & NavbarProps & PageProps & FooterProps
+> {
+  render() {
+    const { hero, isHomePage, children, ...rest } = this.props
+    const hasHero = hero !== null && isHomePage
+    return (
+      <>
+        <Navbar {...rest as NavbarProps}>{hasHero ? hero : null}</Navbar>
+        <Page hasHero={hasHero} {...rest as PageProps}>
+          {children}
+        </Page>
+        <Footer {...rest as FooterProps} />
+      </>
+    )
+  }
+}

--- a/src/containers/App/App.tsx
+++ b/src/containers/App/App.tsx
@@ -11,7 +11,7 @@ export default class App extends React.PureComponent<
 > {
   render() {
     const { hero, isHomePage, children, ...rest } = this.props
-    const hasHero = hero !== null && isHomePage
+    const hasHero = hero != null && isHomePage
     return (
       <>
         <Navbar {...rest as NavbarProps}>{hasHero ? hero : null}</Navbar>

--- a/src/containers/App/App.types.tsx
+++ b/src/containers/App/App.types.tsx
@@ -1,0 +1,6 @@
+export type AppProps = {
+  hero: React.ReactNode
+  isHomePage: boolean
+}
+
+export type MapStateProps = Pick<AppProps, 'isHomePage'>

--- a/src/containers/App/index.ts
+++ b/src/containers/App/index.ts
@@ -1,0 +1,2 @@
+import App from './App.container'
+export default App

--- a/src/containers/Navbar/Navbar.container.tsx
+++ b/src/containers/Navbar/Navbar.container.tsx
@@ -9,7 +9,8 @@ import {
   isConnecting
 } from '../../modules/wallet/selectors'
 import { isEnabled } from '../../modules/translation/selectors'
-import { connectWalletRequest } from '../../modules/wallet/actions'
+import { isSignIn } from '../../modules/location/selectors'
+import { navigateToSignIn } from '../../modules/location/actions'
 import { RootDispatch } from '../../types'
 
 const mapState = (state: any): MapStateProps => {
@@ -19,6 +20,7 @@ const mapState = (state: any): MapStateProps => {
     address: wallet.address,
     isConnected: isConnected(state),
     isConnecting: isConnecting(state),
+    isSignIn: isSignIn(state),
     hasTranslations: isEnabled(state)
   }
 }
@@ -26,7 +28,7 @@ const mapState = (state: any): MapStateProps => {
 const mapDispatch = (
   dispatch: RootDispatch<RouterAction>
 ): MapDispatchProps => ({
-  onSignIn: () => dispatch(connectWalletRequest())
+  onSignIn: () => dispatch(navigateToSignIn())
 })
 
 const mergeProps = (

--- a/src/containers/Navbar/Navbar.types.tsx
+++ b/src/containers/Navbar/Navbar.types.tsx
@@ -6,7 +6,12 @@ export type NavbarProps = NavbarComponentProps & {
 
 export type MapStateProps = Pick<
   NavbarProps,
-  'mana' | 'address' | 'isConnected' | 'isConnecting' | 'hasTranslations'
+  | 'mana'
+  | 'address'
+  | 'isConnected'
+  | 'isConnecting'
+  | 'isSignIn'
+  | 'hasTranslations'
 >
 
 export type MapDispatchProps = Pick<NavbarProps, 'onSignIn'>

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -1,3 +1,4 @@
+export { default as App } from './App'
 export { default as EtherscanLink } from './EtherscanLink'
 export { default as Footer } from './Footer'
 export { default as Navbar } from './Navbar'

--- a/src/modules/location/actions.ts
+++ b/src/modules/location/actions.ts
@@ -5,3 +5,15 @@ export const NAVIGATE_TO = 'Navigate to URL'
 export const navigateTo = (url: string) => action(NAVIGATE_TO, { url })
 
 export type NavigateToAction = ReturnType<typeof navigateTo>
+
+export const NAVIGATE_TO_SIGN_IN = 'Navigate to sign in'
+
+export const navigateToSignIn = () => action(NAVIGATE_TO_SIGN_IN)
+
+export type NavigateToSignInAction = ReturnType<typeof navigateToSignIn>
+
+export const NAVIGATE_TO_ROOT = 'Navigate to root'
+
+export const navigateToRoot = () => action(NAVIGATE_TO_ROOT)
+
+export type NavigateToRootAction = ReturnType<typeof navigateToRoot>

--- a/src/modules/location/reducer.ts
+++ b/src/modules/location/reducer.ts
@@ -1,0 +1,21 @@
+import { Locations } from './types'
+
+export type LocationState = {
+  locations: Locations
+}
+
+export const defaultLocations: Locations = {
+  root: '/',
+  signIn: '/sign-in'
+}
+
+export function createLocationReducer(options: Partial<Locations> = {}) {
+  const locations: Locations = Object.assign({}, defaultLocations, options)
+
+  const INITIAL_STATE: LocationState = { locations }
+  return function locationReducer(state: LocationState = INITIAL_STATE) {
+    return state
+  }
+}
+
+export const locationReducer = createLocationReducer()

--- a/src/modules/location/sagas.ts
+++ b/src/modules/location/sagas.ts
@@ -1,9 +1,24 @@
 import { takeLatest, put, select, ForkEffect } from 'redux-saga/effects'
 import { push } from 'react-router-redux'
-import { NavigateToAction, NAVIGATE_TO } from './actions'
+
+import {
+  NavigateToAction,
+  NAVIGATE_TO,
+  navigateTo,
+  NAVIGATE_TO_SIGN_IN,
+  NAVIGATE_TO_ROOT,
+  NavigateToSignInAction,
+  NavigateToRootAction
+} from './actions'
+import { CONNECT_WALLET_SUCCESS } from '../wallet/actions'
+import { isSignIn, getLocations } from './selectors'
+import { Locations } from './types'
 
 export function* locationSaga(): IterableIterator<ForkEffect> {
   yield takeLatest(NAVIGATE_TO, handleNavigateTo)
+  yield takeLatest(NAVIGATE_TO_SIGN_IN, handleNavigateToSignIn)
+  yield takeLatest(NAVIGATE_TO_ROOT, handleNavigateToRoot)
+  yield takeLatest(CONNECT_WALLET_SUCCESS, handleConnectWalletSuccess)
 }
 
 function* handleNavigateTo(action: NavigateToAction) {
@@ -14,5 +29,22 @@ function* handleNavigateTo(action: NavigateToAction) {
   )
   if (pathname + search !== action.payload.url) {
     yield put(push(action.payload.url))
+  }
+}
+
+function* handleNavigateToSignIn(_: NavigateToSignInAction) {
+  const locations: Locations = yield select(getLocations)
+  yield put(navigateTo(locations.signIn))
+}
+
+function* handleNavigateToRoot(_: NavigateToRootAction) {
+  const locations: Locations = yield select(getLocations)
+  yield put(navigateTo(locations.root))
+}
+
+function* handleConnectWalletSuccess() {
+  if (yield select(isSignIn)) {
+    const locations: Locations = yield select(getLocations)
+    yield put(navigateTo(locations.root))
   }
 }

--- a/src/modules/location/selectors.ts
+++ b/src/modules/location/selectors.ts
@@ -1,4 +1,6 @@
 import { RouterState } from 'react-router-redux'
+import { Locations } from './types'
+import { LocationState } from '../../../node_modules/@types/history'
 
 export const hasRouter = (state: any): boolean => !!state.router
 
@@ -25,4 +27,18 @@ export const getPathAction = (state: any): string | null => {
     return null
   }
   return pathname.split('/').pop() as string | null
+}
+
+export const getState = (state: any): LocationState => state.location
+
+export const getLocations = (state: any): Locations => getState(state).locations
+
+export const isSignIn = (state: any): boolean => {
+  const pathname = getPathname(state)
+  return pathname === getLocations(state).signIn
+}
+
+export const isRoot = (state: any): boolean => {
+  const pathname = getPathname(state)
+  return pathname === getLocations(state).root
 }

--- a/src/modules/location/types.ts
+++ b/src/modules/location/types.ts
@@ -1,0 +1,4 @@
+export type Locations = {
+  root: string
+  signIn: string
+}

--- a/src/modules/transaction/reducer.ts
+++ b/src/modules/transaction/reducer.ts
@@ -1,5 +1,7 @@
+import { txUtils } from 'decentraland-eth'
+
 import { Transaction } from './types'
-import { getTransactionFromAction } from './utils'
+import { getTransactionFromAction, isPending } from './utils'
 import { loadingReducer, LoadingState } from '../loading/reducer'
 import {
   FetchTransactionRequestAction,
@@ -21,8 +23,6 @@ import {
   FixRevertedTransactionAction,
   FIX_REVERTED_TRANSACTION
 } from './actions'
-import { txUtils } from 'decentraland-eth'
-import { isPending } from './utils'
 
 export type TransactionState = {
   data: Transaction[]
@@ -148,7 +148,6 @@ export function transactionReducer(
         error: null,
         data: state.data.map(
           (transaction: Transaction) =>
-            // prettier-ignore
             action.payload.hash === transaction.hash
               ? {
                   ...transaction,
@@ -164,7 +163,6 @@ export function transactionReducer(
         error: null,
         data: state.data.map(
           (transaction: Transaction) =>
-            // prettier-ignore
             action.payload.hash === transaction.hash
               ? {
                   ...transaction,

--- a/src/modules/transaction/sagas.ts
+++ b/src/modules/transaction/sagas.ts
@@ -297,7 +297,7 @@ function* handleWatchRevertedTransaction(
     )
     if (tx != null && tx.type === TRANSACTION_TYPES.confirmed) {
       yield put(fixRevertedTransaction(hash))
-      return
+      return undefined
     }
   } while (!isExpired(txInState, REVERTED_TRANSACTION_THRESHOLD))
 }

--- a/src/modules/translation/defaults/ja.json
+++ b/src/modules/translation/defaults/ja.json
@@ -24,9 +24,9 @@
       },
       "menu": {
         "agora": "Agora",
-        "blog": "ブログ",
-        "docs": "ドキュメント",
-        "marketplace": "マーケット"
+        "blog": "Blog",
+        "docs": "Docs",
+        "marketplace": "Marketplace"
       }
     },
     "sign_in": {

--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -31,7 +31,7 @@ export function createWalletSaga({
     try {
       if (isApprovableWallet()) {
         const { ethereum } = window as EthereumWindow
-        yield call(() => ethereum!.enable())
+        yield call(() => ethereum!.enable!())
 
         // Unfortunately we need to override the provider supplied to this method
         // if we're dealing with approbable wallets (the first being Metamask, probably more to come).

--- a/src/modules/wallet/types.ts
+++ b/src/modules/wallet/types.ts
@@ -24,6 +24,6 @@ export interface EthereumWindow {
     _metamask: { isApproved: () => Promise<boolean> }
     isApproved: () => Promise<boolean>
 
-    enable: () => Promise<string[]>
+    enable?: () => Promise<string[]>
   }
 }

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -76,7 +76,7 @@ export async function isWalletApproved(): Promise<boolean> {
   // `Promise.race` will *not* cancel the slower promise
   let hasFinished = false
 
-  return await Promise.race([
+  return Promise.race([
     approvable.isApproved().then(result => {
       hasFinished = true
       return result

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,9 @@
       { "printWidth": 80, "singleQuote": true, "semi": false }
     ],
     "quotemark": [true, "single", "jsx-double"],
-    "jsx-boolean-value": [false]
+    "jsx-boolean-value": [false],
+    "strict-type-predicates": false,
+    "ter-indent": false
   },
   "linterOptions": {
     "exclude": ["config/**/*.js", "node_modules/**/*.ts", "./**/*.js"]


### PR DESCRIPTION
This PR adds common functionality for the `location` module regarding the sign in page and the home page.

It also adds an `<App>` container that can be used to easily bootstrap an application that basically combines the `Navbar`, `Footer` and `Page` components.

I also updated the README with this new stuff and added missing documentation from previous releases.