### PR TITLE
feat: modal changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Common modules for our dApps
   - [Navbar](https://github.com/decentraland/decentraland-dapps#navbar)
   - [Footer](https://github.com/decentraland/decentraland-dapps#footer)
   - [SignInPage](https://github.com/decentraland/decentraland-dapps#signinpage)
+  - [Modal](https://github.com/decentraland/decentraland-dapps#modal)
   - [EtherscanLink](https://github.com/decentraland/decentraland-dapps#etherscanlink)
 - [Components](https://github.com/decentraland/decentraland-dapps#components)
   - [Intercom](https://github.com/decentraland/decentraland-dapps#intercom)
@@ -1059,6 +1060,7 @@ export { default as HelpModal } from './HelpModal'
 Each modal will receive the properties defined on the `ModalComponent` type, found on `modules/modal/types`, so for example:
 
 ```tsx
+import { Modal } from 'decentraland-ui'
 import { ModalProps } from 'decentraland-dapps/dist/modules/modal/types'
 
 type HelpModalProps = ModalProps & {
@@ -1066,19 +1068,16 @@ type HelpModalProps = ModalProps & {
 }
 
 export default class HelpModal extends React.Component<HelpModalProps> {
-  onClose = () => {
-    const { modal, onClose } = this.props
-    closeModal(modal.name)
-  }
-
   render() {
-    const { modal } = this.props
-    // Do something with modal.metadata
-    // The Modal component here can be whatever you like, just make sure to call closeModal(name) when you want to close it, to update the state
-    return <Modal open={modal.open} onClose={onClose} />
+    const { name, metadata, onClose } = this.props
+    // The Modal component here can be whatever you like, just make sure to call onClose when you want to close it, to update the state
+    // For more examples check the advanced usage
+    return <Modal open={true} className={name} onClose={onClose} />
   }
 }
 ```
+
+If want to use [decentraland-ui's Modal](https://github.com/decentraland/ui) but you don't want to repeat the `open`, `className` and `onClose` props, you can use this module's [Modal](https://github.com/decentraland/decentraland-dapps#modal)
 
 **Reducer**:
 
@@ -1432,6 +1431,41 @@ export default class MyApp extends React.Component {
     )
   }
 }
+```
+
+## Modal
+
+The `<Modal>` it's a shorthand for some common features used by modals provided to [ModalProvider](https://github.com/decentraland/decentraland-dapps#modal).
+
+### Usage
+
+```tsx
+import * as React from 'react'
+import Modal from 'decentraland-dapps/dist/containers/Modal'
+
+export default class MyComponent extends React.PureComponent {
+  render() {
+    return (
+      const { name } = this.props
+
+      <Modal name={name} {/* Other Modal props from decentraland ui */>
+        <Modal.Header>
+        </Modal.Header>
+        <Modal.Description>
+        </Modal.Description>
+      </Modal>
+    )
+  }
+}
+```
+
+Behind the scenes Modal is setting the following properties:
+
+```js
+open={true}
+className={name}
+size="small"
+onClose={/*close the modal by name*/}
 ```
 
 ## EtherscanLink

--- a/src/components/Intercom/index.ts
+++ b/src/components/Intercom/index.ts
@@ -1,3 +1,2 @@
 import Intercom from './Intercom'
-
 export default Intercom

--- a/src/containers/EtherscanLink/EtherscanLink.container.ts
+++ b/src/containers/EtherscanLink/EtherscanLink.container.ts
@@ -1,7 +1,8 @@
 import { connect } from 'react-redux'
-import { getNetwork } from '../../modules/wallet/selectors'
+
 import EtherscanLink from './EtherscanLink'
 import { MapStateProps, MapDispatchProps } from './EtherscanLink.types'
+import { getNetwork } from '../../modules/wallet/selectors'
 
 const mapState = (state: any): MapStateProps => {
   return {

--- a/src/containers/Modal/Modal.container.ts
+++ b/src/containers/Modal/Modal.container.ts
@@ -1,0 +1,31 @@
+import { connect } from 'react-redux'
+import { RouterAction } from 'react-router-redux'
+
+import Modal from './Modal'
+import { ModalProps, MapStateProps, MapDispatchProps } from './Modal.types'
+import { RootDispatch } from '../../types'
+import { closeModal } from '../../modules/modal/actions'
+
+const mapState = (_: any): MapStateProps => ({})
+
+const mapDispatch = (
+  dispatch: RootDispatch<RouterAction>
+): MapDispatchProps => ({
+  onCloseModal: (name: string) => dispatch(closeModal(name))
+})
+
+const mergeProps = (
+  stateProps: MapStateProps,
+  dispatchProps: MapDispatchProps,
+  ownProps: ModalProps
+): ModalProps => ({
+  ...stateProps,
+  ...dispatchProps,
+  ...ownProps
+})
+
+export default connect(
+  mapState,
+  mapDispatch,
+  mergeProps
+)(Modal) as any

--- a/src/containers/Modal/Modal.tsx
+++ b/src/containers/Modal/Modal.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import { Modal as ModalComponent } from 'decentraland-ui'
+
+import { ModalProps } from './Modal.types'
+
+export default class Modal extends React.PureComponent<ModalProps> {
+  handleOnClose = () => {
+    const { name, onCloseModal } = this.props
+    onCloseModal(name)
+  }
+
+  render() {
+    const { name, ...modalProps } = this.props
+
+    return (
+      <ModalComponent
+        open={true}
+        className={name}
+        size="small"
+        onClose={this.handleOnClose}
+        {...modalProps}
+      />
+    )
+  }
+}

--- a/src/containers/Modal/Modal.tsx
+++ b/src/containers/Modal/Modal.tsx
@@ -4,7 +4,7 @@ import { Modal as ModalComponent } from 'decentraland-ui'
 import { ModalProps } from './Modal.types'
 
 export default class Modal extends React.PureComponent<ModalProps> {
-  handleOnClose = () => {
+  handleClose = () => {
     const { name, onCloseModal } = this.props
     onCloseModal(name)
   }
@@ -17,7 +17,7 @@ export default class Modal extends React.PureComponent<ModalProps> {
         open={true}
         className={name}
         size="small"
-        onClose={this.handleOnClose}
+        onClose={this.handleClose}
         {...modalProps}
       />
     )

--- a/src/containers/Modal/Modal.types.ts
+++ b/src/containers/Modal/Modal.types.ts
@@ -1,0 +1,25 @@
+import * as React from 'react'
+import {
+  ModalProps as ModalComponentProps,
+  ModalActions,
+  ModalContent,
+  ModalDescription,
+  ModalHeader
+} from 'decentraland-ui'
+
+import { closeModal } from '../../modules/modal/actions'
+
+export type ModalProps = ModalComponentProps & {
+  name: string
+  onCloseModal: typeof closeModal
+}
+
+export interface ModalComponent extends React.PureComponent<ModalProps> {
+  Actions: typeof ModalActions
+  Content: typeof ModalContent
+  Description: typeof ModalDescription
+  Header: typeof ModalHeader
+}
+
+export type MapStateProps = {}
+export type MapDispatchProps = Pick<ModalProps, 'onCloseModal'>

--- a/src/containers/Modal/index.tsx
+++ b/src/containers/Modal/index.tsx
@@ -1,0 +1,9 @@
+import { Modal as ModalComponent } from 'decentraland-ui'
+import Modal from './Modal.container'
+
+Modal.Actions = ModalComponent.Actions
+Modal.Content = ModalComponent.Content
+Modal.Description = ModalComponent.Description
+Modal.Header = ModalComponent.Header
+
+export default Modal

--- a/src/modules/modal/types.ts
+++ b/src/modules/modal/types.ts
@@ -3,7 +3,3 @@ export type Modal = {
   name: string
   metadata: any
 }
-
-export type ModalProps = {
-  modal: Modal
-}

--- a/src/providers/ModalProvider/ModalProvider.container.ts
+++ b/src/providers/ModalProvider/ModalProvider.container.ts
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { RootDispatch } from '../../types'
 import { getState as getModals } from '../../modules/modal/selectors'
+import { closeModal } from '../../modules/modal/actions'
 import { MapStateProps, MapDispatchProps } from './ModalProvider.types'
 import ModalProvider from './ModalProvider'
 
@@ -8,7 +9,9 @@ const mapState = (state: any): MapStateProps => ({
   modals: getModals(state)
 })
 
-const mapDispatch = (_: RootDispatch): MapDispatchProps => ({})
+const mapDispatch = (dispatch: RootDispatch): MapDispatchProps => ({
+  onClose: (name: string) => dispatch(closeModal(name))
+})
 
 export default connect(
   mapState,

--- a/src/providers/ModalProvider/ModalProvider.tsx
+++ b/src/providers/ModalProvider/ModalProvider.tsx
@@ -1,11 +1,14 @@
 import * as React from 'react'
 
-import { ModalProps } from '../../modules/modal/types'
-import { DefaultProps, Props } from './ModalProvider.types'
+import { DefaultProps, Props, ModalComponent } from './ModalProvider.types'
 
 export default class ModalProvider extends React.PureComponent<Props> {
   static defaultProps: DefaultProps = {
     children: null
+  }
+
+  getOnClose(name: string) {
+    return () => this.props.onClose(name)
   }
 
   render() {
@@ -19,13 +22,16 @@ export default class ModalProvider extends React.PureComponent<Props> {
         continue
       }
 
-      const ModalComponent: React.ComponentType<ModalProps> = components[name]
+      const Component: ModalComponent = components[name]
 
-      if (!ModalComponent) {
+      if (!Component) {
         throw new Error(`Couldn't find a modal Component named "${name}"`)
       }
 
-      ModalComponents.push(<ModalComponent key={name} modal={modal} />)
+      const onClose = this.getOnClose(modal.name)
+      ModalComponents.push(
+        <Component key={name} name={name} onClose={onClose} />
+      )
     }
 
     return (

--- a/src/providers/ModalProvider/ModalProvider.tsx
+++ b/src/providers/ModalProvider/ModalProvider.tsx
@@ -15,12 +15,14 @@ export default class ModalProvider extends React.PureComponent<Props> {
 
     for (const name in modals) {
       const modal = modals[name]
-      let ModalComponent: React.ComponentType<ModalProps> = components[name]
+      if (!modal.open) {
+        continue
+      }
+
+      const ModalComponent: React.ComponentType<ModalProps> = components[name]
 
       if (!ModalComponent) {
-        if (name) {
-          throw new Error(`Couldn't find a modal Component named "${name}"`)
-        }
+        throw new Error(`Couldn't find a modal Component named "${name}"`)
       }
 
       ModalComponents.push(<ModalComponent key={name} modal={modal} />)

--- a/src/providers/ModalProvider/ModalProvider.tsx
+++ b/src/providers/ModalProvider/ModalProvider.tsx
@@ -30,7 +30,12 @@ export default class ModalProvider extends React.PureComponent<Props> {
 
       const onClose = this.getOnClose(modal.name)
       ModalComponents.push(
-        <Component key={name} name={name} onClose={onClose} />
+        <Component
+          key={name}
+          name={name}
+          metadata={modal.metadata}
+          onClose={onClose}
+        />
       )
     }
 

--- a/src/providers/ModalProvider/ModalProvider.tsx
+++ b/src/providers/ModalProvider/ModalProvider.tsx
@@ -7,7 +7,7 @@ export default class ModalProvider extends React.PureComponent<Props> {
     children: null
   }
 
-  getOnClose(name: string) {
+  getCloseHandler(name: string) {
     return () => this.props.onClose(name)
   }
 
@@ -28,7 +28,7 @@ export default class ModalProvider extends React.PureComponent<Props> {
         throw new Error(`Couldn't find a modal Component named "${name}"`)
       }
 
-      const onClose = this.getOnClose(modal.name)
+      const onClose = this.getCloseHandler(modal.name)
       ModalComponents.push(
         <Component
           key={name}

--- a/src/providers/ModalProvider/ModalProvider.types.ts
+++ b/src/providers/ModalProvider/ModalProvider.types.ts
@@ -1,14 +1,21 @@
 import { ModalState } from '../../modules/modal/reducer'
-import { ModalProps } from '../../modules/modal/types'
+import { closeModal } from '../../modules/modal/actions'
+
+export type ModalProps = {
+  name: string
+  onClose: () => ReturnType<typeof closeModal>
+}
+export type ModalComponent = React.ComponentType<ModalProps>
 
 export type DefaultProps = {
   children: React.ReactNode | null
 }
 
 export type Props = DefaultProps & {
-  components: Record<string, React.ComponentType<ModalProps>>
+  components: Record<string, ModalComponent>
   modals: ModalState
+  onClose: typeof closeModal
 }
 
 export type MapStateProps = Pick<Props, 'modals'>
-export type MapDispatchProps = {}
+export type MapDispatchProps = Pick<Props, 'onClose'>

--- a/src/providers/ModalProvider/ModalProvider.types.ts
+++ b/src/providers/ModalProvider/ModalProvider.types.ts
@@ -3,6 +3,7 @@ import { closeModal } from '../../modules/modal/actions'
 
 export type ModalProps = {
   name: string
+  metadata?: any
   onClose: () => ReturnType<typeof closeModal>
 }
 export type ModalComponent = React.ComponentType<ModalProps>


### PR DESCRIPTION
Modal features:
- Adhere more closely to the react lifecycle for modals. `componentWillUnmount` will fire when the modal closes
- Pass down a onClose prop to provider modals

Not sure the added complexity is worth it. We can keep only this commit: https://github.com/decentraland/decentraland-dapps/commit/7af6055206f531f3eeffd810539ed15c289c7e79 (which adds `componentWillUnmount`) if we want to remove it