### PR TITLE
fix: localstorage quota migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "0.0.0-development",
+  "version": "4.0.2-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/lib/localStorage.spec.ts
+++ b/src/lib/localStorage.spec.ts
@@ -38,10 +38,7 @@ describe('localStorage', function() {
       const key = 'key'
       const localStorage = getLocalStorage()
       localStorage.setItem(key, JSON.stringify('{}'))
-      let data = JSON.parse(localStorage.getItem(key) as string)
-      expect(data.storage).to.equal(undefined)
-      migrateStorage(key, migrations)
-      data = JSON.parse(localStorage.getItem(key) as string)
+      const data = migrateStorage(key, migrations)
       expect(data.storage.version).to.equal(2)
       expect(data.data).to.equal('new version')
     })
@@ -51,8 +48,7 @@ describe('localStorage', function() {
       const localStorage = getLocalStorage()
 
       localStorage.setItem(key, JSON.stringify('{ storage: { version: null }}'))
-      migrateStorage(key, migrations)
-      let data = JSON.parse(localStorage.getItem(key) as string)
+      const data = migrateStorage(key, migrations)
       expect(data.storage.version).to.equal(2)
     })
 
@@ -60,13 +56,12 @@ describe('localStorage', function() {
       const key = 'key'
       const localStorage = getLocalStorage()
       localStorage.setItem(key, JSON.stringify('{}'))
-      let data = JSON.parse(localStorage.getItem(key) as string)
-      expect(data.storage).to.equal(undefined)
-      migrateStorage(key, migrations)
-      data = JSON.parse(localStorage.getItem(key) as string)
+      let data = migrateStorage(key, migrations)
       expect(data.storage.version).to.equal(2)
 
-      migrateStorage(key, migrations)
+      localStorage.setItem(key, JSON.stringify(data))
+
+      data = migrateStorage(key, migrations)
       expect(data.storage.version).to.equal(2)
     })
   })

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -23,7 +23,10 @@ export function getLocalStorage(): LocalStorage {
       }
 }
 
-export function migrateStorage<T>(key: string, migrations: Migrations<T>) {
+export function migrateStorage<T>(
+  key: string,
+  migrations: Migrations<T>
+): T | null {
   let version = 1
   const localStorage = getLocalStorage()
   const dataString = localStorage.getItem(key)
@@ -38,7 +41,7 @@ export function migrateStorage<T>(key: string, migrations: Migrations<T>) {
 
     while (migrations[nextVersion]) {
       data = migrations[nextVersion](data)
-      if (data.storage) {
+      if (!data.storage) {
         data.storage = {}
       }
       data.storage.version = nextVersion

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -29,7 +29,7 @@ export function migrateStorage<T>(key: string, migrations: Migrations<T>) {
   const dataString = localStorage.getItem(key)
 
   if (dataString) {
-    const data = JSON.parse(dataString as string)
+    let data = JSON.parse(dataString)
 
     if (data.storage && data.storage.version) {
       version = parseInt(data.storage.version, 10)
@@ -37,15 +37,16 @@ export function migrateStorage<T>(key: string, migrations: Migrations<T>) {
     let nextVersion = version + 1
 
     while (migrations[nextVersion]) {
-      const newData = migrations[nextVersion](data)
-      localStorage.setItem(
-        key,
-        JSON.stringify({
-          ...(newData as Object),
-          storage: { version: nextVersion }
-        })
-      )
+      data = migrations[nextVersion](data)
+      if (data.storage) {
+        data.storage = {}
+      }
+      data.storage.version = nextVersion
       nextVersion++
     }
+
+    return data
   }
+
+  return null
 }


### PR DESCRIPTION
Make sure migrations still run in-memory when the LS quota is exceeded.
Fixes an issue in the Builder