### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             - dependencies-{{ checksum "package-lock.json" }}
       - run:
           name: Install node dependencies
-          command: npm install
+          command: npm ci
       - save_cache:
           paths:
             - node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "4.0.2-rc",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -243,6 +243,59 @@
           "dev": true
         }
       }
+    },
+    "@redux-saga/core": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.0.3.tgz",
+      "integrity": "sha512-zf8h5N0oTzaNeSMxOWH9GJMB9IRSM8JubDsrZVsvVltXjzFFSR8DNt7tbPoRJUK0hFfQB1it+bL+dEMWpD7wXA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "@redux-saga/deferred": "^1.0.1",
+        "@redux-saga/delay-p": "^1.0.1",
+        "@redux-saga/is": "^1.0.2",
+        "@redux-saga/symbols": "^1.0.1",
+        "@redux-saga/types": "^1.0.2",
+        "redux": ">=0.10 <5",
+        "typescript-tuple": "^2.1.0"
+      }
+    },
+    "@redux-saga/deferred": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.0.1.tgz",
+      "integrity": "sha512-+gW5xQ93QXOOmRLAmX8x2Hx1HpbTG6CM6+HcdTSbJovh4uMWaGyeDECnqXSt8QqA/ja3s2nqYXLqXFKepIQ1hw==",
+      "dev": true
+    },
+    "@redux-saga/delay-p": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.0.1.tgz",
+      "integrity": "sha512-0SnNDyDLUyB4NThtptAwiprNOnbCNhoed/Rp5JwS7SB+a/AdWynVgg/E6BmjsggLFNr07KW0bzn05tsPRBuU7Q==",
+      "dev": true,
+      "requires": {
+        "@redux-saga/symbols": "^1.0.1"
+      }
+    },
+    "@redux-saga/is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.0.2.tgz",
+      "integrity": "sha512-WnaUOwYvPK2waWjzebT4uhL8zY76XNkzzpJ2EQJe8bN1tByvAjvT7MuJZTSshOhdHL5PsRO0MsH224XIXBJidQ==",
+      "dev": true,
+      "requires": {
+        "@redux-saga/symbols": "^1.0.1",
+        "@redux-saga/types": "^1.0.2"
+      }
+    },
+    "@redux-saga/symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.0.1.tgz",
+      "integrity": "sha512-akKkzcVnb1RzJaZV2LQFbi51abvdICMuAKwwLoCjjxLbLAGIw9EJxk5ucNnWSSCEsoEQMeol5tkAcK+Xzuv1Bg==",
+      "dev": true
+    },
+    "@redux-saga/types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.0.2.tgz",
+      "integrity": "sha512-8/qcMh15507AnXJ3lBeuhsdFwnWQqnp68EpUuHlYPixJ5vjVmls7/Jq48cnUlrZI8Jd9U1jkhfCl0gaT5KMgVw==",
+      "dev": true
     },
     "@semantic-release/commit-analyzer": {
       "version": "6.0.1",
@@ -3895,12 +3948,19 @@
       "dev": true
     },
     "axios": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
-        "follow-redirects": "^1.2.5",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        }
       }
     },
     "babel-code-frame": {
@@ -4663,11 +4723,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.1.0.tgz",
       "integrity": "sha512-VOMDtYPwLbIncTxNoSzRyvaMxtXmLWLUqr8k5AfC1BzLk34HvBXaQX8snOwQZ4c0aX8aSERqtJSiI9/m2u5kuA==",
-      "dev": true
-    },
-    "bignumber.js": {
-      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-      "from": "bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
       "dev": true
     },
     "bindings": {
@@ -5785,8 +5840,36 @@
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "dev": true,
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
+      },
+      "dependencies": {
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#8431eab7b3384e65e8126a4602520b78031666fb",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "dev": true,
+          "requires": {
+            "bn.js": "^4.11.8",
+            "ethereumjs-util": "^6.0.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+              "integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+              "dev": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "0.1.6",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        }
       }
     },
     "eth-tx-summary": {
@@ -5816,7 +5899,7 @@
           "integrity": "sha512-NamWuMBIl8kmkJFVj8WzGatySTzQPQag4Xr677yFxdVtIxACFbL/dQowk0MzEqIKk93U1TwY3MjVU6mOcwZnKA==",
           "dev": true,
           "requires": {
-            "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+            "async-eventemitter": "async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
             "eth-query": "^2.1.0",
             "ethereumjs-tx": "^1.3.3",
             "ethereumjs-util": "^5.1.3",
@@ -5902,15 +5985,6 @@
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.0.18.tgz",
       "integrity": "sha1-L9w1dvIykDNYl26znaeDIT/5Uj8=",
       "dev": true
-    },
-    "ethereumjs-abi": {
-      "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-      "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.10.0",
-        "ethereumjs-util": "^5.0.0"
-      }
     },
     "ethereumjs-account": {
       "version": "2.0.5",
@@ -6341,11 +6415,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.2.tgz",
-      "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "=3.1.0"
       }
     },
     "for-each": {
@@ -6982,7 +7056,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -12161,6 +12236,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -13103,7 +13179,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -14870,10 +14947,13 @@
       }
     },
     "redux-saga": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-0.16.0.tgz",
-      "integrity": "sha1-CiMdsKFIkwHdmA9vL4jYztQY9yQ=",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.0.3.tgz",
+      "integrity": "sha512-ORo16st4cvrS+tpthMi6mJz1mMIuM//0EKFPAZjKTvDglRDebc7vTOJa0oeqT0iAZeYupusAstprFb0+3YDw/w==",
+      "dev": true,
+      "requires": {
+        "@redux-saga/core": "^1.0.3"
+      }
     },
     "redux-storage": {
       "version": "4.1.2",
@@ -15098,12 +15178,28 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "ripemd160": {
@@ -16252,6 +16348,12 @@
           "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.24.tgz",
           "integrity": "sha512-5YaBKa6oFuWy7ptIFMATyftIcpZTZtvgrzPThEbs+kl4Uu41oUxiRunG0k32QZjD6MXMELls//ry/epNxc11aQ==",
           "dev": true
+        },
+        "typescript": {
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+          "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+          "dev": true
         }
       }
     },
@@ -16307,10 +16409,34 @@
       "integrity": "sha512-3qnSDBNtH3mfekmM9w/IVlsqiUT4I5m+mpLp5tV2Ua/28BfaehqUg6eQNC8+cTk+oufbXcubLiWvKS/61qgleQ=="
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
       "dev": true
+    },
+    "typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "dev": true,
+      "requires": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q==",
+      "dev": true
+    },
+    "typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "dev": true,
+      "requires": {
+        "typescript-compare": "^0.0.2"
+      }
     },
     "u2f-api": {
       "version": "0.2.7",
@@ -16521,11 +16647,18 @@
       "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
       "dev": true,
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2-cookies": "^1.1.0",
         "xmlhttprequest": "*"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+          "dev": true
+        }
       }
     },
     "web3-provider-engine": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@types/redux-storage-engine-localstorage": "^1.1.0",
     "@types/segment-analytics": "0.0.28",
     "@types/uuid": "^3.4.3",
-    "axios": "^0.17.0",
+    "axios": "^0.19.0",
     "date-fns": "^1.29.0",
     "flat": "^4.1.0",
     "react-intl": "^2.4.0",
@@ -47,12 +47,13 @@
     "react-redux": "^5.0.7",
     "react-router-redux": "^5.0.0-alpha.6",
     "redux": "^3.7.2",
-    "redux-saga": "^0.16.0",
+    "redux-saga": "^1.0.3",
+    "rimraf": "^2.6.3",
     "semantic-release": "^15.9.15",
     "ts-node": "^7.0.0",
     "tslint-language-service": "^0.9.9",
     "tslint-plugin-prettier": "^1.3.0",
-    "typescript": "^2.9.2",
+    "typescript": "^3.5.2",
     "validate-commit-message": "^3.0.1"
   },
   "peerDependencies": {
@@ -62,7 +63,7 @@
     "react-redux": "^5.0.7",
     "react-router-redux": "^5.0.0-alpha.6",
     "redux": "^3.7.2",
-    "redux-saga": "^0.16.0"
+    "redux-saga": "^1.0.3"
   },
   "prettier": {
     "printWidth": 80,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,7 +15,7 @@ export class BaseAPI {
   constructor(public url: string) {}
 
   request(
-    method: string,
+    method: AxiosRequestConfig['method'],
     path: string,
     params: APIParam | null = null,
     axiosRequestConfig: AxiosRequestConfig = {}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -39,12 +39,12 @@ export function toObjectByKey<T extends Object>(
   currentValues: DataByKey<T> = {},
   key: keyof T
 ): DataByKey<T> {
-  return values.reduce(
-    (valueHash, value) => ({
-      ...valueHash,
-      [value[key].toString()]: value
-    }),
-    currentValues
+  return values.reduce<DataByKey<T>>(
+    (obj, value) => {
+      obj[value[key] as any] = value
+      return obj
+    },
+    { ...currentValues }
   )
 }
 

--- a/src/modules/transaction/sagas.ts
+++ b/src/modules/transaction/sagas.ts
@@ -5,9 +5,9 @@ import {
   select,
   takeEvery,
   ForkEffect,
-  fork
+  fork,
+  delay
 } from 'redux-saga/effects'
-import { delay } from 'redux-saga'
 import { Transaction } from './types'
 import {
   fetchTransactionFailure,

--- a/src/modules/translation/utils.ts
+++ b/src/modules/translation/utils.ts
@@ -100,6 +100,7 @@ function _mergeTranslations<T extends { [key: string]: T | string }>(
   source: T = {} as T
 ) {
   const merged: T = Object.keys(source).reduce((result: T, key: string) => {
+    // @ts-ignore
     result[key] =
       typeof source[key] === 'object'
         ? _mergeTranslations(target[key] as T, source[key] as T)


### PR DESCRIPTION
BREAKING CHANGE: peer dependency redux-saga had a major updgrade

Some dependencies had major upgrades, like `typescript` and `axios`. I had to refactor a few utils to comply with typescript v3. I also fixed several vulnerabilities in the package-lock with an `npm audit fix`.

Since one peer dependency had a major upgrade, I labeled this commit as breaking, because it required action on the user's end in order to upgrade to the next version.

I made a release candidate to test it: `decentraland-dapps@5.0.0-rc`