### PR TITLE
feat: split enable and connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "6.2.3-rc",
+  "version": "0.0.0-development",
   "main": "dist",
   "dependencies": {
     "@types/flat": "0.0.28",

--- a/src/containers/SignInPage/SignInPage.container.ts
+++ b/src/containers/SignInPage/SignInPage.container.ts
@@ -9,7 +9,7 @@ import {
 } from './SignInPage.types'
 import { RootDispatch } from '../../types'
 import { isEnabled } from '../../modules/translation/selectors'
-import { connectWalletRequest } from '../../modules/wallet/actions'
+import { enableWalletRequest } from '../../modules/wallet/actions'
 import {
   isConnecting,
   isConnected,
@@ -24,7 +24,7 @@ const mapState = (state: any): MapStateProps => ({
 })
 
 const mapDispatch = (dispatch: RootDispatch): MapDispatchProps => ({
-  onConnect: () => dispatch(connectWalletRequest())
+  onConnect: () => dispatch(enableWalletRequest())
 })
 
 export default connect<

--- a/src/modules/wallet/actions.ts
+++ b/src/modules/wallet/actions.ts
@@ -5,7 +5,7 @@ export const CONNECT_WALLET_REQUEST = '[Request] Connect Wallet'
 export const CONNECT_WALLET_SUCCESS = '[Success] Connect Wallet'
 export const CONNECT_WALLET_FAILURE = '[Failure] Connect Wallet'
 
-export const connectWalletRequest = () => action(CONNECT_WALLET_REQUEST, {})
+export const connectWalletRequest = () => action(CONNECT_WALLET_REQUEST)
 export const connectWalletSuccess = (wallet: Wallet) =>
   action(CONNECT_WALLET_SUCCESS, { wallet })
 export const connectWalletFailure = (error: string) =>
@@ -14,3 +14,16 @@ export const connectWalletFailure = (error: string) =>
 export type ConnectWalletRequestAction = ReturnType<typeof connectWalletRequest>
 export type ConnectWalletSuccessAction = ReturnType<typeof connectWalletSuccess>
 export type ConnectWalletFailureAction = ReturnType<typeof connectWalletFailure>
+
+export const ENABLE_WALLET_REQUEST = '[Request] Enable Wallet'
+export const ENABLE_WALLET_SUCCESS = '[Success] Enable Wallet'
+export const ENABLE_WALLET_FAILURE = '[Failure] Enable Wallet'
+
+export const enableWalletRequest = () => action(ENABLE_WALLET_REQUEST)
+export const enableWalletSuccess = () => action(ENABLE_WALLET_SUCCESS)
+export const enableWalletFailure = (error: string) =>
+  action(ENABLE_WALLET_FAILURE, { error })
+
+export type EnableWalletRequestAction = ReturnType<typeof enableWalletRequest>
+export type EnableWalletSuccessAction = ReturnType<typeof enableWalletSuccess>
+export type EnableWalletFailureAction = ReturnType<typeof enableWalletFailure>


### PR DESCRIPTION
**BREAKING CHANGE**: if not using the `WalletProvider` and `SignInPage` components, you may need to change your `connectWalletRequest` to a `enableWalletRequest`

The purpose of this PR is to remove the `ethereum.enable()` call from the `connectWalletRequest` saga. This is because currently our dapps try to connect to ethereum as soon as they boot, and if the domain has never been enabled before MetaMask will prompt the user with a popup to enable it, which is a very crappy experience. 

I created a separate action `enableWalletRequest` that performs the `ethereum.enable()` call and then if successful a `connectWalletRequest` action is triggered automatically.

So the usage now is basically the following:

1) Trigger a `connectWalletRequest` action when the dapp boots, if the website was already enabled it will connect, otherwise it will fail but you will just appear as signed out.

2) Any "Sign In" or  "Connect wallet" button in the dapp should trigger a `enableWalletRequest`, which will prompt the user to enable the website (only if it's the first time, otherwise it will connect right away).

For dapps using the `WalletProvider` and `SignInPage` components there's nothing to change, since those were updated accordingly in this PR: basically `WalletProvider` does what's stated in point 1, and  `SignInPage` does what's in point 2.
