### PR TITLE
feat: handle network and account changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,34 +139,6 @@ export function* rootSaga() {
 }
 ```
 
-### Advanced Usage
-
-You can change the address of the MANA token contract (ie. if you want to use it from Ropsten)
-
-<details><summary>Learn More</summary>
-<p>
-
-Instead of importing `walletSaga`, use `createWalletSaga`:
-
-**Saga**:
-
-```ts
-import { all } from 'redux-saga/effects'
-import { createWalletSaga } from 'decentraland-dapps/dist/modules/wallet/sagas'
-
-const walletSaga = createWalletSaga({ MANA_ADDRESS: process.env.MANA_ADDRESS })
-
-export function* rootSaga() {
-  yield all([
-    walletSaga()
-    // your other sagas here
-  ])
-}
-```
-
-</p>
-</details>
-
 ## Storage
 
 The storage module allows you to save parts of the redux store in localStorage to make them persistent and migrate it from different versions without loosing it.

--- a/src/modules/wallet/actions.ts
+++ b/src/modules/wallet/actions.ts
@@ -27,3 +27,17 @@ export const enableWalletFailure = (error: string) =>
 export type EnableWalletRequestAction = ReturnType<typeof enableWalletRequest>
 export type EnableWalletSuccessAction = ReturnType<typeof enableWalletSuccess>
 export type EnableWalletFailureAction = ReturnType<typeof enableWalletFailure>
+
+export const CHANGE_ACCOUNT = 'Change Account'
+export const changeAccount = (address: string) =>
+  action(CHANGE_ACCOUNT, { address })
+export type ChangeAccountAction = ReturnType<typeof changeAccount>
+
+export const CHANGE_NETWORK = 'Change Network'
+export const changeNetwork = (network: number) =>
+  action(CHANGE_NETWORK, { network })
+export type ChangeNetworkAction = ReturnType<typeof changeNetwork>
+
+export const DISCONNECT_WALLET = 'Disconnect'
+export const disconnectWallet = () => action(DISCONNECT_WALLET)
+export type DisconnectWalletAction = ReturnType<typeof disconnectWallet>

--- a/src/modules/wallet/actions.ts
+++ b/src/modules/wallet/actions.ts
@@ -29,13 +29,13 @@ export type EnableWalletSuccessAction = ReturnType<typeof enableWalletSuccess>
 export type EnableWalletFailureAction = ReturnType<typeof enableWalletFailure>
 
 export const CHANGE_ACCOUNT = 'Change Account'
-export const changeAccount = (address: string) =>
-  action(CHANGE_ACCOUNT, { address })
+export const changeAccount = (wallet: Wallet) =>
+  action(CHANGE_ACCOUNT, { wallet })
 export type ChangeAccountAction = ReturnType<typeof changeAccount>
 
 export const CHANGE_NETWORK = 'Change Network'
-export const changeNetwork = (network: number) =>
-  action(CHANGE_NETWORK, { network })
+export const changeNetwork = (wallet: Wallet) =>
+  action(CHANGE_NETWORK, { wallet })
 export type ChangeNetworkAction = ReturnType<typeof changeNetwork>
 
 export const DISCONNECT_WALLET = 'Disconnect'

--- a/src/modules/wallet/reducer.ts
+++ b/src/modules/wallet/reducer.ts
@@ -7,7 +7,9 @@ import {
   ConnectWalletFailureAction,
   CONNECT_WALLET_REQUEST,
   CONNECT_WALLET_SUCCESS,
-  CONNECT_WALLET_FAILURE
+  CONNECT_WALLET_FAILURE,
+  DisconnectWalletAction,
+  DISCONNECT_WALLET
 } from './actions'
 
 export type WalletState = {
@@ -26,6 +28,7 @@ export type WalletReducerAction =
   | ConnectWalletRequestAction
   | ConnectWalletSuccessAction
   | ConnectWalletFailureAction
+  | DisconnectWalletAction
 
 export function walletReducer(
   state: WalletState = INITIAL_STATE,
@@ -49,6 +52,12 @@ export function walletReducer(
         loading: loadingReducer(state.loading, action),
         error: action.payload.error
       }
+    case DISCONNECT_WALLET: {
+      return {
+        ...state,
+        data: null
+      }
+    }
     default:
       return state
   }

--- a/src/modules/wallet/reducer.ts
+++ b/src/modules/wallet/reducer.ts
@@ -9,7 +9,11 @@ import {
   CONNECT_WALLET_SUCCESS,
   CONNECT_WALLET_FAILURE,
   DisconnectWalletAction,
-  DISCONNECT_WALLET
+  DISCONNECT_WALLET,
+  ChangeAccountAction,
+  ChangeNetworkAction,
+  CHANGE_ACCOUNT,
+  CHANGE_NETWORK
 } from './actions'
 
 export type WalletState = {
@@ -29,6 +33,8 @@ export type WalletReducerAction =
   | ConnectWalletSuccessAction
   | ConnectWalletFailureAction
   | DisconnectWalletAction
+  | ChangeAccountAction
+  | ChangeNetworkAction
 
 export function walletReducer(
   state: WalletState = INITIAL_STATE,
@@ -40,6 +46,8 @@ export function walletReducer(
         ...state,
         loading: loadingReducer(state.loading, action)
       }
+    case CHANGE_ACCOUNT:
+    case CHANGE_NETWORK:
     case CONNECT_WALLET_SUCCESS:
       return {
         loading: loadingReducer(state.loading, action),

--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -1,7 +1,5 @@
-import { Eth } from 'web3x-es/eth'
-import { Address } from 'web3x-es/address'
-import { fromWei } from 'web3x-es/utils'
 import { put, call, all, takeEvery } from 'redux-saga/effects'
+import { isMobile } from '../../lib/utils'
 import {
   connectWalletSuccess,
   connectWalletFailure,
@@ -12,117 +10,72 @@ import {
   EnableWalletSuccessAction,
   connectWalletRequest,
   ENABLE_WALLET_REQUEST,
-  ENABLE_WALLET_SUCCESS,
-  ChangeAccountAction,
-  ChangeNetworkAction,
-  CHANGE_ACCOUNT,
-  CHANGE_NETWORK
+  ENABLE_WALLET_SUCCESS
 } from './actions'
-import { isMobile } from '../../lib/utils'
-import { MANA } from '../../contracts/MANA'
-import { Wallet } from './types'
+import { getWallet } from './utils'
 
-export type WalletSagaOptions = {
-  MANA_ADDRESS: string
+function* handleConnectWalletRequest() {
+  try {
+    // Hack for old providers and mobile providers which do not have a hack to convert send to sendAsync
+    const provider = (window as any).ethereum
+    if (
+      isMobile() &&
+      provider &&
+      typeof provider.sendAsync === 'function' &&
+      provider.send !== provider.sendAsync
+    ) {
+      provider.send = provider.sendAsync
+    }
+
+    // prevent metamask from auto refreshing the page
+    if (provider) {
+      provider.autoRefreshOnNetworkChange = false
+    }
+
+    const wallet = yield call(() => getWallet())
+    yield put(connectWalletSuccess(wallet))
+  } catch (error) {
+    yield put(connectWalletFailure(error.message))
+  }
+}
+
+function* handleEnableWalletRequest(_action: EnableWalletRequestAction) {
+  try {
+    const accounts: string[] = yield call(() => {
+      const provider = (window as any).ethereum
+      if (provider && provider.enable) {
+        return provider.enable()
+      }
+      console.warn('Provider not found')
+      return []
+    })
+    if (accounts.length === 0) {
+      throw new Error('Enable did not return any accounts')
+    }
+    yield put(enableWalletSuccess())
+  } catch (error) {
+    yield put(enableWalletFailure(error.message))
+  }
+}
+
+function* handleEnableWalletSuccess(_action: EnableWalletSuccessAction) {
+  yield put(connectWalletRequest())
+}
+
+export function* walletSaga() {
+  yield all([
+    takeEvery(CONNECT_WALLET_REQUEST, handleConnectWalletRequest),
+    takeEvery(ENABLE_WALLET_REQUEST, handleEnableWalletRequest),
+    takeEvery(ENABLE_WALLET_SUCCESS, handleEnableWalletSuccess)
+  ])
 }
 
 export function createWalletSaga(
-  options: WalletSagaOptions = {
-    MANA_ADDRESS: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942'
-  }
+  // @ts-ignore
+  options?: { MANA_ADDRESS: string }
 ) {
-  const { MANA_ADDRESS } = options
-  function* handleConnectWalletRequest() {
-    try {
-      // Hack for old providers and mobile providers which does not have a hack to convert send to sendAsync
-      const provider = (window as any).ethereum
-      if (
-        isMobile() &&
-        provider &&
-        typeof provider.sendAsync === 'function' &&
-        provider.send !== provider.sendAsync
-      ) {
-        provider.send = provider.sendAsync
-      }
-
-      const eth = Eth.fromCurrentProvider()
-      if (!eth) {
-        // this could happen if metamask is not installed
-        throw new Error('Could not connect to Ethereum')
-      }
-      let accounts: Address[] = yield call(() => eth.getAccounts())
-      if (accounts.length === 0) {
-        // This could happen if metamask was not enabled
-        throw new Error('Could not get address')
-      }
-      const address = accounts[0]
-      const network = yield call(() => eth.getId())
-      const ethBalance = yield call(() => eth.getBalance(address))
-      const mana = new MANA(eth, Address.fromString(MANA_ADDRESS))
-      let manaBalance
-      try {
-        manaBalance = yield call(() => mana.methods.balanceOf(address).call())
-      } catch (e) {
-        // Temporary fix. We should detect that the user should change the network
-        console.warn(
-          'Could not get MANA balance. Are you in the right network?'
-        )
-        manaBalance = '0'
-      }
-
-      const wallet: Wallet = {
-        address: address.toString(),
-        mana: parseFloat(fromWei(manaBalance, 'ether')),
-        eth: parseFloat(fromWei(ethBalance, 'ether')),
-        network
-      }
-
-      yield put(connectWalletSuccess(wallet))
-    } catch (error) {
-      yield put(connectWalletFailure(error.message))
-    }
-  }
-
-  function* handleEnableWalletRequest(_action: EnableWalletRequestAction) {
-    try {
-      const accounts: string[] = yield call(() => {
-        const provider = (window as any).ethereum
-        if (provider && provider.enable) {
-          return provider.enable()
-        }
-        console.warn('Provider not found')
-        return []
-      })
-      if (accounts.length === 0) {
-        throw new Error('Enable did not return any accounts')
-      }
-      yield put(enableWalletSuccess())
-    } catch (error) {
-      yield put(enableWalletFailure(error.message))
-    }
-  }
-
-  function* handleEnableWalletSuccess(_action: EnableWalletSuccessAction) {
-    yield put(connectWalletRequest())
-  }
-
-  function* handleChangeAccount(_action: ChangeAccountAction) {
-    yield put(connectWalletRequest())
-  }
-
-  function* handleChangeNetwork(_action: ChangeNetworkAction) {
-    yield put(connectWalletRequest())
-  }
-
-  return function* walletSaga() {
-    yield all([
-      takeEvery(CONNECT_WALLET_REQUEST, handleConnectWalletRequest),
-      takeEvery(ENABLE_WALLET_REQUEST, handleEnableWalletRequest),
-      takeEvery(ENABLE_WALLET_SUCCESS, handleEnableWalletSuccess),
-      takeEvery(CHANGE_ACCOUNT, handleChangeAccount),
-      takeEvery(CHANGE_NETWORK, handleChangeNetwork)
-    ])
-  }
+  console.warn(
+    'Deprecated notice: `createWalletSaga` has been deprecated and will be removed in future version, use `walletSaga` instead.'
+  )
+  return walletSaga
 }
-
-export const walletSaga = createWalletSaga()

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -4,11 +4,15 @@ import { fromWei } from 'web3x-es/utils'
 import { MANA } from '../../contracts/MANA'
 import { Wallet } from './types'
 
-const MANA_ADDRESS = {
-  '1': '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
-  '3': '0x2a8fd99c19271f4f04b1b7b9c4f7cf264b626edb',
-  '4': '0x28bce5263f5d7f4eb7e8c6d5d78275ca455bac63',
-  '42': '0x230fc362413d9e862326c2c7084610a5a2fdf78a'
+const MANA_ADDRESS_BY_NETWORK = {
+  // Mainnet
+  1: '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
+  // Ropsten
+  3: '0x2a8fd99c19271f4f04b1b7b9c4f7cf264b626edb',
+  // Rinkeby
+  4: '0x28bce5263f5d7f4eb7e8c6d5d78275ca455bac63',
+  // Kovan
+  42: '0x230fc362413d9e862326c2c7084610a5a2fdf78a'
 }
 
 export async function getWallet() {
@@ -27,7 +31,10 @@ export async function getWallet() {
   const ethBalance = await eth.getBalance(address)
   let manaBalance = '0'
   try {
-    const mana = new MANA(eth, Address.fromString(MANA_ADDRESS[network]))
+    const mana = new MANA(
+      eth,
+      Address.fromString(MANA_ADDRESS_BY_NETWORK[network])
+    )
     manaBalance = await mana.methods.balanceOf(address).call()
   } catch (e) {
     // Temporary fix. We should detect that the user should change the network

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -1,0 +1,45 @@
+import { Eth } from 'web3x-es/eth'
+import { Address } from 'web3x-es/address'
+import { fromWei } from 'web3x-es/utils'
+import { MANA } from '../../contracts/MANA'
+import { Wallet } from './types'
+
+const MANA_ADDRESS = {
+  '1': '0x0f5d2fb29fb7d3cfee444a200298f468908cc942',
+  '3': '0x2a8fd99c19271f4f04b1b7b9c4f7cf264b626edb',
+  '4': '0x28bce5263f5d7f4eb7e8c6d5d78275ca455bac63',
+  '42': '0x230fc362413d9e862326c2c7084610a5a2fdf78a'
+}
+
+export async function getWallet() {
+  const eth = Eth.fromCurrentProvider()
+  if (!eth) {
+    // this could happen if metamask is not installed
+    throw new Error('Could not connect to Ethereum')
+  }
+  let accounts: Address[] = await eth.getAccounts()
+  if (accounts.length === 0) {
+    // This could happen if metamask was not enabled
+    throw new Error('Could not get address')
+  }
+  const address = accounts[0]
+  const network = await eth.getId()
+  const ethBalance = await eth.getBalance(address)
+  let manaBalance = '0'
+  try {
+    const mana = new MANA(eth, Address.fromString(MANA_ADDRESS[network]))
+    manaBalance = await mana.methods.balanceOf(address).call()
+  } catch (e) {
+    // Temporary fix. We should detect that the user should change the network
+    console.warn('Could not get MANA balance')
+  }
+
+  const wallet: Wallet = {
+    address: address.toString(),
+    mana: parseFloat(fromWei(manaBalance, 'ether')),
+    eth: parseFloat(fromWei(ethBalance, 'ether')),
+    network
+  }
+
+  return wallet
+}

--- a/src/providers/WalletProvider/WalletProvider.container.ts
+++ b/src/providers/WalletProvider/WalletProvider.container.ts
@@ -1,5 +1,9 @@
 import { connect } from 'react-redux'
-import { connectWalletRequest } from '../../modules/wallet/actions'
+import {
+  connectWalletRequest,
+  changeAccount,
+  changeNetwork
+} from '../../modules/wallet/actions'
 import {
   MapStateProps,
   MapDispatchProps,
@@ -10,7 +14,9 @@ import WalletProvider from './WalletProvider'
 const mapState = (_: any): MapStateProps => ({})
 
 const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onConnect: () => dispatch(connectWalletRequest())
+  onConnect: () => dispatch(connectWalletRequest()),
+  onChangeAccount: address => dispatch(changeAccount(address)),
+  onChangeNetwork: network => dispatch(changeNetwork(network))
 })
 
 export default connect(

--- a/src/providers/WalletProvider/WalletProvider.ts
+++ b/src/providers/WalletProvider/WalletProvider.ts
@@ -1,28 +1,30 @@
 import React from 'react'
 import { Eth } from 'web3x-es/eth'
 import { EthereumProvider } from 'web3x-es/providers/ethereum-provider'
+import { getWallet } from '../../modules/wallet/utils'
 import { Props } from './WalletProvider.types'
 
 export default class WalletProvider extends React.PureComponent<Props> {
   eth = Eth.fromCurrentProvider()
 
-  // handle account change
   handleChangeAccount = async () => {
-    if (!this.eth) return
     const { onChangeAccount } = this.props
-    const accounts = await this.eth.getAccounts()
-    if (accounts.length > 0) {
-      const address = accounts[0].toString()
-      onChangeAccount(address)
+    try {
+      const wallet = await getWallet()
+      onChangeAccount(wallet)
+    } catch (error) {
+      // nada
     }
   }
 
-  // handle network change
   handleChangeNetwork = async () => {
-    if (!this.eth) return
     const { onChangeNetwork } = this.props
-    const network = await this.eth.getId()
-    onChangeNetwork(network)
+    try {
+      const wallet = await getWallet()
+      onChangeNetwork(wallet)
+    } catch (error) {
+      // nada
+    }
   }
 
   handle(

--- a/src/providers/WalletProvider/WalletProvider.ts
+++ b/src/providers/WalletProvider/WalletProvider.ts
@@ -2,7 +2,15 @@ import React from 'react'
 import { Eth } from 'web3x-es/eth'
 import { EthereumProvider } from 'web3x-es/providers/ethereum-provider'
 import { getWallet } from '../../modules/wallet/utils'
-import { Props } from './WalletProvider.types'
+import {
+  Props,
+  EventType,
+  Handler,
+  EmitterMethod,
+  AccountsChangedHandler,
+  NetworkChangedHandler
+} from './WalletProvider.types'
+import { getInjectedProvider } from './utils'
 
 export default class WalletProvider extends React.PureComponent<Props> {
   eth = Eth.fromCurrentProvider()
@@ -27,25 +35,39 @@ export default class WalletProvider extends React.PureComponent<Props> {
     }
   }
 
-  handle(
-    method: 'on' | 'removeListener',
-    type: 'accountsChanged' | 'networkChanged',
-    handler: Function
+  call(
+    provider: EthereumProvider,
+    method: EmitterMethod,
+    type: EventType,
+    handler: Handler
   ) {
+    switch (type) {
+      case 'accountsChanged':
+        provider[method](type, handler as AccountsChangedHandler)
+        break
+      case 'networkChanged':
+        provider[method](type, handler as NetworkChangedHandler)
+        break
+      default:
+      // do nothing
+    }
+  }
+
+  handle(method: EmitterMethod, type: EventType, handler: Handler) {
     // try to use web3x abstraction
     if (this.eth) {
       try {
-        this.eth.provider[method](type as any, handler as any)
+        this.call(this.eth.provider, method, type, handler)
         return // all good, early return
       } catch (error) {
         // it fails if legacy provider (ie. metamask legacy provider)
       }
     }
     // fallback using web3 (this works with metamask)
-    const provider = (window as any).ethereum as (EthereumProvider | undefined)
+    const provider = getInjectedProvider()
     if (provider) {
       try {
-        provider[method](type as any, handler as any)
+        this.call(provider, method, type, handler)
       } catch (error) {
         // it fails if provider is not standard (ie. dapper legacy provider)
         console.warn(
@@ -57,11 +79,11 @@ export default class WalletProvider extends React.PureComponent<Props> {
     }
   }
 
-  on(type: 'accountsChanged' | 'networkChanged', handler: Function) {
+  on(type: EventType, handler: Handler) {
     this.handle('on', type, handler)
   }
 
-  off(type: 'accountsChanged' | 'networkChanged', handler: Function) {
+  off(type: EventType, handler: Handler) {
     this.handle('removeListener', type, handler)
   }
 

--- a/src/providers/WalletProvider/WalletProvider.ts
+++ b/src/providers/WalletProvider/WalletProvider.ts
@@ -13,7 +13,7 @@ export default class WalletProvider extends React.PureComponent<Props> {
       const wallet = await getWallet()
       onChangeAccount(wallet)
     } catch (error) {
-      // nada
+      // do nothing
     }
   }
 
@@ -23,7 +23,7 @@ export default class WalletProvider extends React.PureComponent<Props> {
       const wallet = await getWallet()
       onChangeNetwork(wallet)
     } catch (error) {
-      // nada
+      // do nothing
     }
   }
 

--- a/src/providers/WalletProvider/WalletProvider.ts
+++ b/src/providers/WalletProvider/WalletProvider.ts
@@ -28,23 +28,32 @@ export default class WalletProvider extends React.PureComponent<Props> {
   }
 
   handle(
-    action: 'on' | 'removeListener',
+    method: 'on' | 'removeListener',
     type: 'accountsChanged' | 'networkChanged',
     handler: Function
   ) {
     // try to use web3x abstraction
     if (this.eth) {
       try {
-        this.eth.provider[action](type as any, handler as any)
+        this.eth.provider[method](type as any, handler as any)
         return // all good, early return
       } catch (error) {
-        // it fails if legacy provider (ie. metamask)
+        // it fails if legacy provider (ie. metamask legacy provider)
       }
     }
     // fallback using web3 (this works with metamask)
     const provider = (window as any).ethereum as (EthereumProvider | undefined)
     if (provider) {
-      provider[action](type as any, handler as any)
+      try {
+        provider[method](type as any, handler as any)
+      } catch (error) {
+        // it fails if provider is not standard (ie. dapper legacy provider)
+        console.warn(
+          `Could not use method "${method}" on provider`,
+          provider,
+          `Error: ${error.message}`
+        )
+      }
     }
   }
 

--- a/src/providers/WalletProvider/WalletProvider.types.ts
+++ b/src/providers/WalletProvider/WalletProvider.types.ts
@@ -1,17 +1,27 @@
+import { Dispatch } from 'redux'
 import {
   connectWalletRequest,
-  ConnectWalletRequestAction
+  ConnectWalletRequestAction,
+  changeAccount,
+  changeNetwork,
+  ChangeAccountAction,
+  ChangeNetworkAction
 } from '../../modules/wallet/actions'
-import { Dispatch } from 'redux'
 
-export type DefaultProps = {
+export type Props = {
+  address?: string
+  network?: number
   children: React.ReactNode | null
-}
-
-export type Props = DefaultProps & {
   onConnect: typeof connectWalletRequest
+  onChangeAccount: typeof changeAccount
+  onChangeNetwork: typeof changeNetwork
 }
 
-export type MapStateProps = {}
-export type MapDispatchProps = Pick<Props, 'onConnect'>
-export type MapDispatch = Dispatch<ConnectWalletRequestAction>
+export type MapStateProps = Pick<Props, 'address' | 'network'>
+export type MapDispatchProps = Pick<
+  Props,
+  'address' | 'network' | 'onConnect' | 'onChangeAccount' | 'onChangeNetwork'
+>
+export type MapDispatch = Dispatch<
+  ConnectWalletRequestAction | ChangeAccountAction | ChangeNetworkAction
+>

--- a/src/providers/WalletProvider/WalletProvider.types.ts
+++ b/src/providers/WalletProvider/WalletProvider.types.ts
@@ -1,3 +1,4 @@
+import { EthereumProvider } from 'web3x-es/providers/ethereum-provider'
 import { Dispatch } from 'redux'
 import {
   connectWalletRequest,
@@ -25,3 +26,10 @@ export type MapDispatchProps = Pick<
 export type MapDispatch = Dispatch<
   ConnectWalletRequestAction | ChangeAccountAction | ChangeNetworkAction
 >
+
+export type EventType = 'accountsChanged' | 'networkChanged'
+export type EmitterMethod = 'on' | 'removeListener'
+export type AccountsChangedHandler = (accounts: string[]) => void
+export type NetworkChangedHandler = (network: string) => void
+export type Handler = AccountsChangedHandler | NetworkChangedHandler
+export type ProviderWindow = Window & { ethereum?: EthereumProvider }

--- a/src/providers/WalletProvider/utils.ts
+++ b/src/providers/WalletProvider/utils.ts
@@ -1,0 +1,3 @@
+import { ProviderWindow } from './WalletProvider.types'
+
+export const getInjectedProvider = () => (window as ProviderWindow).ethereum

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,0 +1,3 @@
+export { default as ModalProvider } from './ModalProvider'
+export { default as TranslationProvider } from './TranslationProvider'
+export { default as WalletProvider } from './WalletProvider'


### PR DESCRIPTION
This PR adds new functionality:

- New actions added: `CHANGE_ACCOUNT`, `CHANGE_NETWORK` and `DISCONNET_WALLET`

- `WalletProvider` dispatches `CHANGE_ACCOUNT` and `CHANGE_NETWORK` actions when a change is detected, so dApps can react to it.

- `disconnectWallet()` can be dispatched to go back to non-connected state.

Changes:

There are no breaking changes, although now it's not possible to set the `MANA_ADDRESS` from the outside. This renders `createWalletSaga` obsolete, but I left it with a deprecation warning encouraging users to import `walletSaga` directly instead.

This can be tested using the release candidate `decentraland-dapps@7.4.0-rc8`.

I deployed a version of the marketplace using this for easier manual testing here: https://public-930mdxzai.now.sh/