### PR TITLE
fix: don't mark tx as REVERTED when in block, check tx receipt status instead.

### DIFF
--- a/src/modules/transaction/txUtils.ts
+++ b/src/modules/transaction/txUtils.ts
@@ -83,11 +83,21 @@ export async function getTransaction(
 
   const receipt = await eth.getTransactionReceipt(hash)
 
+  if (receipt == null) {
+    // pending (in block, but not yet mined)
+    const tx: PendingTransaction = {
+      status: TransactionStatus.PENDING,
+      ...response
+    }
+    return tx
+  }
+
   // reverted
-  if (receipt == null || !receipt.status) {
+  if (!receipt.status) {
     const tx: RevertedTransaction = {
       status: TransactionStatus.REVERTED,
-      ...response
+      ...response,
+      receipt
     }
     return tx
   }

--- a/src/modules/transaction/types.ts
+++ b/src/modules/transaction/types.ts
@@ -33,6 +33,7 @@ export type PendingTransaction = TransactionResponse & {
 
 export type RevertedTransaction = TransactionResponse & {
   status: TransactionStatus.REVERTED
+  receipt: TransactionReceipt
 }
 
 export type ConfirmedTransaction = TransactionResponse & {


### PR DESCRIPTION
Fixes #81.