### PR TITLE
fix: metamask migration

### DIFF
--- a/src/containers/SignInPage/SignInPage.tsx
+++ b/src/containers/SignInPage/SignInPage.tsx
@@ -9,7 +9,7 @@ import { isMobile, isCucumberProvider } from '../../lib/utils'
 export default class SignInPage extends React.PureComponent<
   SignInPageProps,
   SignInPageState
-  > {
+> {
   constructor(props: SignInPageProps) {
     super(props)
     this.state = {
@@ -40,9 +40,10 @@ export default class SignInPage extends React.PureComponent<
       connect: <T id="@dapps.sign_in.connect" />,
       connecting: <T id="@dapps.sign_in.connecting" />,
       connected: <T id="@dapps.sign_in.connected" />,
-      message: isCucumberProvider() ?
+      message: isCucumberProvider() ? (
         <T
-          id="@dapps.sign_in.options.samsung" values={{
+          id="@dapps.sign_in.options.samsung"
+          values={{
             samsung_link: (
               <a
                 href="https://www.samsung.com/global/galaxy/apps/samsung-blockchain/"
@@ -54,55 +55,55 @@ export default class SignInPage extends React.PureComponent<
             )
           }}
         />
-        : isMobile() ? (
-          <T
-            id="@dapps.sign_in.options.mobile"
-            values={{
-              coinbase_link: (
-                <a
-                  href="https://wallet.coinbase.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Coinbase Wallet
-                </a>
-              ),
-              imtoken_link: (
-                <a
-                  href="https://token.im"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  imToken
-                </a>
-              )
-            }}
-          />
-        ) : (
-            <T
-              id="@dapps.sign_in.options.desktop"
-              values={{
-                metamask_link: (
-                  <a
-                    href="https://metamask.io"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    MetaMask
-                  </a>
-                ),
-                ledger_nano_link: (
-                  <a
-                    href="https://www.ledger.com/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Ledger Nano S
-                  </a>
-                )
-              }}
-            />
-          )
+      ) : isMobile() ? (
+        <T
+          id="@dapps.sign_in.options.mobile"
+          values={{
+            coinbase_link: (
+              <a
+                href="https://wallet.coinbase.com"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Coinbase Wallet
+              </a>
+            ),
+            imtoken_link: (
+              <a
+                href="https://token.im"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                imToken
+              </a>
+            )
+          }}
+        />
+      ) : (
+        <T
+          id="@dapps.sign_in.options.desktop"
+          values={{
+            metamask_link: (
+              <a
+                href="https://metamask.io"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                MetaMask
+              </a>
+            ),
+            ledger_nano_link: (
+              <a
+                href="https://www.ledger.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Ledger Nano S
+              </a>
+            )
+          }}
+        />
+      )
     }
   }
 

--- a/src/lib/eth.ts
+++ b/src/lib/eth.ts
@@ -1,0 +1,16 @@
+import { Eth } from 'web3x-es/eth'
+import {
+  LegacyProviderAdapter,
+  LegacyProvider,
+  EthereumProvider
+} from 'web3x-es/providers'
+
+export async function getProvider(): Promise<EthereumProvider | null> {
+  const { ethereum } = window as Window & { ethereum?: LegacyProvider }
+  return ethereum ? new LegacyProviderAdapter(ethereum) : null
+}
+
+export async function createEth() {
+  const provider = await getProvider()
+  return provider ? new Eth(provider) : null
+}

--- a/src/lib/eth.ts
+++ b/src/lib/eth.ts
@@ -1,13 +1,18 @@
 import { Eth } from 'web3x-es/eth'
-import {
-  LegacyProviderAdapter,
-  LegacyProvider,
-  EthereumProvider
-} from 'web3x-es/providers'
+import { LegacyProviderAdapter, EthereumProvider } from 'web3x-es/providers'
 
-export async function getProvider(): Promise<EthereumProvider | null> {
-  const { ethereum } = window as Window & { ethereum?: LegacyProvider }
-  return ethereum ? new LegacyProviderAdapter(ethereum) : null
+export type Provider = EthereumProvider & {
+  enable?: () => Promise<string[]>
+  isCucumber?: boolean
+}
+
+export type EthereumWindow = Window & {
+  ethereum?: Provider
+}
+
+export async function getProvider(): Promise<Provider | null> {
+  const { ethereum } = window as EthereumWindow
+  return ethereum ? new LegacyProviderAdapter(ethereum as any) : null
 }
 
 export async function createEth() {

--- a/src/lib/eth.ts
+++ b/src/lib/eth.ts
@@ -12,10 +12,10 @@ export type EthereumWindow = Window & {
 
 export async function getProvider(): Promise<Provider | null> {
   const { ethereum } = window as EthereumWindow
-  return ethereum ? new LegacyProviderAdapter(ethereum as any) : null
+  return ethereum ? ethereum : null
 }
 
 export async function createEth() {
   const provider = await getProvider()
-  return provider ? new Eth(provider) : null
+  return provider ? new Eth(new LegacyProviderAdapter(provider as any)) : null
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,7 @@ import dateFnsFormat from 'date-fns/format'
 import dateFnsDistanceInWordsToNow from 'date-fns/distance_in_words_to_now'
 import { Model, ModelById, DataByKey } from './types'
 import { getCurrentLocale } from '../modules/translation/utils'
+import { EthereumProvider } from 'web3x-es/providers'
 
 export function isMobile() {
   // WARN: Super naive mobile device check.
@@ -15,8 +16,12 @@ export function isMobile() {
 }
 
 export function isCucumberProvider() {
-  const provider = (window as any).ethereum
-  return isMobile() && provider && provider.isCucumber
+  const provider = (window as Window & { ethereum?: EthereumProvider }).ethereum
+  return (
+    isMobile() &&
+    !!provider &&
+    !!(provider as EthereumProvider & { isCucumber?: boolean }).isCucumber
+  )
 }
 
 export function insertScript({

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,7 @@ import dateFnsFormat from 'date-fns/format'
 import dateFnsDistanceInWordsToNow from 'date-fns/distance_in_words_to_now'
 import { Model, ModelById, DataByKey } from './types'
 import { getCurrentLocale } from '../modules/translation/utils'
-import { EthereumProvider } from 'web3x-es/providers'
+import { EthereumWindow } from './eth'
 
 export function isMobile() {
   // WARN: Super naive mobile device check.
@@ -16,12 +16,8 @@ export function isMobile() {
 }
 
 export function isCucumberProvider() {
-  const provider = (window as Window & { ethereum?: EthereumProvider }).ethereum
-  return (
-    isMobile() &&
-    !!provider &&
-    !!(provider as EthereumProvider & { isCucumber?: boolean }).isCucumber
-  )
+  const provider = (window as EthereumWindow).ethereum
+  return isMobile() && !!provider && !!provider.isCucumber
 }
 
 export function insertScript({

--- a/src/modules/transaction/sagas.ts
+++ b/src/modules/transaction/sagas.ts
@@ -1,4 +1,3 @@
-import { Eth } from 'web3x-es/eth'
 import { Address } from 'web3x-es/address'
 import { BlockResponse, TransactionResponse } from 'web3x-es/formatters'
 import {
@@ -44,6 +43,7 @@ import {
 import { isPending, buildActionRef } from './utils'
 import { getTransaction as getTransactionFromNetwork } from './txUtils'
 import { getAddress } from '../wallet/selectors'
+import { createEth } from '../../lib/eth'
 
 export function* transactionSaga(): IterableIterator<ForkEffect> {
   yield takeEvery(FETCH_TRANSACTION_REQUEST, handleFetchTransactionRequest)
@@ -169,7 +169,7 @@ function* handleFetchTransactionRequest(action: FetchTransactionRequestAction) {
 function* handleReplaceTransactionRequest(
   action: ReplaceTransactionRequestAction
 ) {
-  const eth = Eth.fromCurrentProvider()
+  const eth = yield call(createEth)
   if (!eth) {
     console.warn('Could not connect to ethereum')
     return

--- a/src/modules/transaction/txUtils.ts
+++ b/src/modules/transaction/txUtils.ts
@@ -1,4 +1,3 @@
-import { Eth } from 'web3x-es/eth'
 import { TransactionResponse } from 'web3x-es/formatters'
 import { Address } from 'web3x-es/address'
 import {
@@ -10,11 +9,12 @@ import {
   RevertedTransaction,
   ConfirmedTransaction
 } from './types'
+import { createEth } from '../../lib/eth'
 
 export async function getTransaction(
   hash: string
 ): Promise<AnyTransaction | null> {
-  const eth = Eth.fromCurrentProvider()
+  const eth = await createEth()
   if (!eth) return null
 
   let accounts: Address[] = []

--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -1,4 +1,4 @@
-import { EthereumProvider } from 'web3x-es/providers'
+import { LegacyProvider } from 'web3x-es/providers'
 import { put, call, all, takeEvery } from 'redux-saga/effects'
 import { isMobile, isCucumberProvider } from '../../lib/utils'
 import {
@@ -17,7 +17,7 @@ import { getWallet } from './utils'
 import { getProvider } from '../../lib/eth'
 
 // Patch Samsung's Cucumber provider send to support promises
-const provider = (window as any).ethereum
+const provider = (window as any).ethereum as LegacyProvider
 
 let cucumberProviderSend: Function
 if (isCucumberProvider()) {
@@ -70,9 +70,7 @@ function* handleConnectWalletRequest() {
 function* handleEnableWalletRequest(_action: EnableWalletRequestAction) {
   try {
     const accounts: string[] = yield call(async () => {
-      const provider:
-        | EthereumProvider & { enable?: () => Promise<string[]> }
-        | null = await getProvider()
+      const provider = await getProvider()
       if (isCucumberProvider()) {
         return cucumberProviderSend('eth_requestAccounts')
       }

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -1,8 +1,8 @@
-import { Eth } from 'web3x-es/eth'
 import { Address } from 'web3x-es/address'
 import { fromWei } from 'web3x-es/utils'
 import { MANA } from '../../contracts/MANA'
 import { Wallet } from './types'
+import { createEth } from '../../lib/eth'
 
 const MANA_ADDRESS_BY_NETWORK = {
   // Mainnet
@@ -16,7 +16,7 @@ const MANA_ADDRESS_BY_NETWORK = {
 }
 
 export async function getWallet() {
-  const eth = Eth.fromCurrentProvider()
+  const eth = await createEth()
   if (!eth) {
     // this could happen if metamask is not installed
     throw new Error('Could not connect to Ethereum')

--- a/src/providers/WalletProvider/utils.ts
+++ b/src/providers/WalletProvider/utils.ts
@@ -1,3 +1,0 @@
-import { ProviderWindow } from './WalletProvider.types'
-
-export const getInjectedProvider = () => (window as ProviderWindow).ethereum


### PR DESCRIPTION
Removes the usage of `Eth.fromCurrentProvider()` (which uses `window.web3` under the hood). Also provides two new helpers: `getProvider(): Promise<EthereumProvider>` and `createEth(): Promise<Eth | null>` that can be used by dapps instead of using `window.ethereum` and `Eth.fromCurrentProvider()`. 

Currently `getProvider` just returns a promise that resolves to `window.ethereum`, but it's abstracted on its own helper so if we add more providers in the future (ie Formatic) the dapps don't need to worry about which provider to use, they just use the `getProvider` helper.

The `createEth` should be used as a replacement for `Eth.fromCurrentProvider()` on all the dapps, in order to comply with this migration: https://github.com/MetaMask/metamask-extension/issues/8077

For example, in our sagas we currently have this:

```ts
const eth = Eth.fromCurrentProvider()
```

And we should replace it with

```ts
const eth = yield call(createEth)
```

or 

```ts
const eth = await createEth()
```

Depending if used within a generator or an async function.

There's a RC with these changes that can be used already to test in our dapps: 

```
npm i decentraland-dapps@7.13.1-rc3
```