### PR TITLE
feat(Authorization): configure meta-tx server url

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,11 +578,16 @@ export const rootReducer = combineReducers({
 
 **Sagas**
 
-Add the `authorizationSaga` to the `rootSaga`:
+Use `createAuthorizationSaga` and add the returned saga to the `rootSaga`:
 
 ```ts
 import { all } from 'redux-saga/effects'
-import { authorizationSaga } from 'decentraland-dapps/dist/modules/authorization/sagas'
+import { createAuthorizationSaga } from 'decentraland-dapps/dist/modules/authorization/sagas'
+
+// if you are not going to use meta transactions you can skip the options or just import `authorizationSaga`
+const authorizationSaga = createAuthorizationSaga({
+  metaTransactionServerUrl: 'https://transactions-api.decentraland.io'
+})
 
 export function* rootSaga() {
   yield all([

--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ export const rootReducer = combineReducers({
 
 **Sagas**
 
-Use `createAuthorizationSaga` and add the returned saga to the `rootSaga`:
+Use `createAuthorizationSaga` and add the returned saga to the `rootSaga`. Alternatively, if you are just going to use this module on Ethereum (which means you won't need meta-transactions) you can just import `authorizationSaga`:
 
 ```ts
 import { all } from 'redux-saga/effects'

--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -28,11 +28,12 @@ import {
   RevokeTokenRequestAction,
   REVOKE_TOKEN_REQUEST
 } from './actions'
-import { Authorization, AuthorizationAction, AuthorizationType } from './types'
-
-export type AuthorizationSagaOptions = {
-  metaTransactionServerUrl?: string
-}
+import {
+  Authorization,
+  AuthorizationAction,
+  AuthorizationSagaOptions,
+  AuthorizationType
+} from './types'
 
 export function createAuthorizationSaga(options?: AuthorizationSagaOptions) {
   return function* authorizationSaga() {

--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -30,147 +30,163 @@ import {
 } from './actions'
 import { Authorization, AuthorizationAction, AuthorizationType } from './types'
 
-export function* authorizationSaga() {
-  yield takeEvery(
-    FETCH_AUTHORIZATIONS_REQUEST,
-    handleFetchAuthorizationsRequest
-  )
-  yield takeEvery(GRANT_TOKEN_REQUEST, handleGrantTokenRequest)
-  yield takeEvery(REVOKE_TOKEN_REQUEST, handleRevokeTokenRequest)
+export type AuthorizationSagaOptions = {
+  metaTransactionServerUrl?: string
 }
 
-function* handleFetchAuthorizationsRequest(
-  action: FetchAuthorizationsRequestAction
-) {
-  try {
-    const { authorizations } = action.payload
-    const authorizationsToStore: Authorization[] = []
+export function createAuthorizationSaga(options?: AuthorizationSagaOptions) {
+  return function* authorizationSaga() {
+    yield takeEvery(
+      FETCH_AUTHORIZATIONS_REQUEST,
+      handleFetchAuthorizationsRequest
+    )
+    yield takeEvery(GRANT_TOKEN_REQUEST, handleGrantTokenRequest)
+    yield takeEvery(REVOKE_TOKEN_REQUEST, handleRevokeTokenRequest)
+  }
 
-    for (const authorization of authorizations) {
-      if (!isValidType(authorization.type)) {
-        throw new Error(`Invalid authorization type ${authorization.type}`)
+  function* handleFetchAuthorizationsRequest(
+    action: FetchAuthorizationsRequestAction
+  ) {
+    try {
+      const { authorizations } = action.payload
+      const authorizationsToStore: Authorization[] = []
+
+      for (const authorization of authorizations) {
+        if (!isValidType(authorization.type)) {
+          throw new Error(`Invalid authorization type ${authorization.type}`)
+        }
+        const { chainId } = authorization
+        const address = Address.fromString(authorization.address)
+        const contractAddress = Address.fromString(
+          authorization.contractAddress
+        )
+        const authorizedAddress = Address.fromString(
+          authorization.authorizedAddress
+        )
+
+        const provider: Provider = yield call(() => getNetworkProvider(chainId))
+        const eth: Eth = new Eth(provider)
+
+        switch (authorization.type) {
+          case AuthorizationType.ALLOWANCE:
+            const allowance: string = yield call(() =>
+              new ERC20(eth, contractAddress).methods
+                .allowance(address, authorizedAddress)
+                .call()
+            )
+            if (parseInt(allowance, 10) > 0) {
+              authorizationsToStore.push(authorization)
+            }
+            break
+          case AuthorizationType.APPROVAL:
+            const isApproved: boolean = yield call(() =>
+              new ERC721(eth, contractAddress).methods
+                .isApprovedForAll(address, authorizedAddress)
+                .call()
+            )
+            if (isApproved) {
+              authorizationsToStore.push(authorization)
+            }
+            break
+        }
       }
-      const { chainId } = authorization
-      const address = Address.fromString(authorization.address)
-      const contractAddress = Address.fromString(authorization.contractAddress)
-      const authorizedAddress = Address.fromString(
-        authorization.authorizedAddress
+
+      yield put(fetchAuthorizationsSuccess(authorizationsToStore))
+    } catch (error) {
+      yield put(fetchAuthorizationsFailure(error.message))
+    }
+  }
+
+  function* handleGrantTokenRequest(action: GrantTokenRequestAction) {
+    try {
+      const { authorization } = action.payload
+      const txHash: string = yield call(() =>
+        changeAuthorization(authorization, AuthorizationAction.GRANT)
       )
+      yield put(grantTokenSuccess(authorization, authorization.chainId, txHash))
+    } catch (error) {
+      yield put(grantTokenFailure(error.message))
+    }
+  }
 
-      const provider: Provider = yield call(() => getNetworkProvider(chainId))
-      const eth: Eth = new Eth(provider)
+  function* handleRevokeTokenRequest(action: RevokeTokenRequestAction) {
+    try {
+      const { authorization } = action.payload
+      const txHash: string = yield call(() =>
+        changeAuthorization(authorization, AuthorizationAction.REVOKE)
+      )
+      yield put(
+        revokeTokenSuccess(authorization, authorization.chainId, txHash)
+      )
+    } catch (error) {
+      yield put(revokeTokenFailure(error.message))
+    }
+  }
 
-      switch (authorization.type) {
-        case AuthorizationType.ALLOWANCE:
-          const allowance: string = yield call(() =>
-            new ERC20(eth, contractAddress).methods
-              .allowance(address, authorizedAddress)
-              .call()
-          )
-          if (parseInt(allowance, 10) > 0) {
-            authorizationsToStore.push(authorization)
-          }
-          break
-        case AuthorizationType.APPROVAL:
-          const isApproved: boolean = yield call(() =>
-            new ERC721(eth, contractAddress).methods
-              .isApprovedForAll(address, authorizedAddress)
-              .call()
-          )
-          if (isApproved) {
-            authorizationsToStore.push(authorization)
-          }
-          break
-      }
+  async function changeAuthorization(
+    authorization: Authorization,
+    action: AuthorizationAction
+  ): Promise<string> {
+    if (!isValidType(authorization.type)) {
+      throw new Error(`Invalid authorization type ${authorization.type}`)
     }
 
-    yield put(fetchAuthorizationsSuccess(authorizationsToStore))
-  } catch (error) {
-    yield put(fetchAuthorizationsFailure(error.message))
-  }
-}
+    const provider: Provider | null = await getConnectedProvider()
+    if (!provider) {
+      throw new Error('Could not connect to Ethereum')
+    }
 
-function* handleGrantTokenRequest(action: GrantTokenRequestAction) {
-  try {
-    const { authorization } = action.payload
-    const txHash: string = yield call(() =>
-      changeAuthorization(authorization, AuthorizationAction.GRANT)
+    const eth: Eth = new Eth(provider)
+    const { network } = getChainConfiguration(authorization.chainId)
+
+    const from = Address.fromString(authorization.address)
+    const contractAddress = Address.fromString(authorization.contractAddress)
+    const authorizedAddress = Address.fromString(
+      authorization.authorizedAddress
     )
-    yield put(grantTokenSuccess(authorization, authorization.chainId, txHash))
-  } catch (error) {
-    yield put(grantTokenFailure(error.message))
+    const { contractName, chainId } = authorization
+
+    let method: TxSend<ERC20TransactionReceipt | ERC721TransactionReceipt>
+
+    switch (authorization.type) {
+      case AuthorizationType.ALLOWANCE:
+        const amount =
+          action === AuthorizationAction.GRANT
+            ? getTokenAmountToApprove().toString()
+            : '0'
+
+        method = new ERC20(eth, contractAddress).methods.approve(
+          authorizedAddress,
+          amount
+        )
+        break
+      case AuthorizationType.APPROVAL:
+        const isApproved = action === AuthorizationAction.GRANT
+
+        method = new ERC721(eth, contractAddress).methods.setApprovalForAll(
+          authorizedAddress,
+          isApproved
+        )
+        break
+    }
+
+    switch (network) {
+      case Network.ETHEREUM:
+        return method.send({ from }).getTxHash()
+      case Network.MATIC:
+        const payload = method.getSendRequestPayload({ from })
+        const txData = payload.params[0].data
+        const metaTxProvider = await getNetworkProvider(chainId)
+        const contract: ContractData = {
+          ...getContract(contractName, chainId),
+          address: contractAddress.toString()
+        }
+
+        return sendMetaTransaction(provider, metaTxProvider, txData, contract, {
+          serverURL: options?.metaTransactionServerUrl
+        })
+    }
   }
 }
 
-function* handleRevokeTokenRequest(action: RevokeTokenRequestAction) {
-  try {
-    const { authorization } = action.payload
-    const txHash: string = yield call(() =>
-      changeAuthorization(authorization, AuthorizationAction.REVOKE)
-    )
-    yield put(revokeTokenSuccess(authorization, authorization.chainId, txHash))
-  } catch (error) {
-    yield put(revokeTokenFailure(error.message))
-  }
-}
-
-async function changeAuthorization(
-  authorization: Authorization,
-  action: AuthorizationAction
-): Promise<string> {
-  if (!isValidType(authorization.type)) {
-    throw new Error(`Invalid authorization type ${authorization.type}`)
-  }
-
-  const provider: Provider | null = await getConnectedProvider()
-  if (!provider) {
-    throw new Error('Could not connect to Ethereum')
-  }
-
-  const eth: Eth = new Eth(provider)
-  const { network } = getChainConfiguration(authorization.chainId)
-
-  const from = Address.fromString(authorization.address)
-  const contractAddress = Address.fromString(authorization.contractAddress)
-  const authorizedAddress = Address.fromString(authorization.authorizedAddress)
-  const { contractName, chainId } = authorization
-
-  let method: TxSend<ERC20TransactionReceipt | ERC721TransactionReceipt>
-
-  switch (authorization.type) {
-    case AuthorizationType.ALLOWANCE:
-      const amount =
-        action === AuthorizationAction.GRANT
-          ? getTokenAmountToApprove().toString()
-          : '0'
-
-      method = new ERC20(eth, contractAddress).methods.approve(
-        authorizedAddress,
-        amount
-      )
-      break
-    case AuthorizationType.APPROVAL:
-      const isApproved = action === AuthorizationAction.GRANT
-
-      method = new ERC721(eth, contractAddress).methods.setApprovalForAll(
-        authorizedAddress,
-        isApproved
-      )
-      break
-  }
-
-  switch (network) {
-    case Network.ETHEREUM:
-      return method.send({ from }).getTxHash()
-    case Network.MATIC:
-      const payload = method.getSendRequestPayload({ from })
-      const txData = payload.params[0].data
-      const metaTxProvider = await getNetworkProvider(chainId)
-      const contract: ContractData = {
-        ...getContract(contractName, chainId),
-        address: contractAddress.toString()
-      }
-
-      return sendMetaTransaction(provider, metaTxProvider, txData, contract)
-  }
-}
+export const authorizationSaga = createAuthorizationSaga()

--- a/src/modules/authorization/types.ts
+++ b/src/modules/authorization/types.ts
@@ -19,3 +19,7 @@ export type Authorization = {
   contractName: ContractName
   chainId: ChainId
 }
+
+export type AuthorizationSagaOptions = {
+  metaTransactionServerUrl?: string
+}

--- a/src/modules/translation/sagas.ts
+++ b/src/modules/translation/sagas.ts
@@ -1,6 +1,6 @@
 import { takeEvery, put, call, ForkEffect } from 'redux-saga/effects'
 import flatten from 'flat'
-import { Translation, TranslationKeys } from './types'
+import { Translation, TranslationKeys, TranslationSagaOptions } from './types'
 import {
   fetchTranslationsSuccess,
   fetchTranslationsFailure,
@@ -9,11 +9,6 @@ import {
 } from './actions'
 import { setCurrentLocale, mergeTranslations } from './utils'
 import * as defaultTranslations from './defaults'
-
-export type TranslationSagaOptions = {
-  getTranslation?: (locale: string) => Promise<Translation>
-  translations?: { [locale: string]: Translation }
-}
 
 export function createTranslationSaga({
   getTranslation,

--- a/src/modules/translation/types.ts
+++ b/src/modules/translation/types.ts
@@ -4,3 +4,8 @@ export interface Translation {
 export interface TranslationKeys {
   [key: string]: string
 }
+
+export type TranslationSagaOptions = {
+  getTranslation?: (locale: string) => Promise<Translation>
+  translations?: { [locale: string]: Translation }
+}


### PR DESCRIPTION
Added a `createAuthorizationSaga` function that accepts an optional configuration object `{ metaTransactionServerUrl?: string }` that allows to configure the `serverUrl` parameter of the `sendMetaTransaction` method used internally by the `authorization` module. The `authorizationSaga` is still exported with a non-configured meta transaction server. I figured is not needed for dapps that only run on Ethereum, but in case we want to make it mandatory to configure it we can remove that exported saga or replace it with a function that throws (that would require a major release instead of a minor one).