### PR TITLE
feat: use multicall for authorizations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,8 @@
     "": {
       "version": "0.0.0-development",
       "dependencies": {
+        "@0xsequence/multicall": "^0.21.5",
+        "@0xsequence/relayer": "^0.21.5",
         "@dcl/schemas": ">=1.1.0",
         "@types/flat": "0.0.28",
         "@types/node": "^10.1.2",
@@ -60,6 +62,87 @@
         "react-redux": "^7.2.4",
         "redux": "^4.1.0",
         "redux-saga": "^1.1.3"
+      }
+    },
+    "node_modules/@0xsequence/abi": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/abi/-/abi-0.21.5.tgz",
+      "integrity": "sha512-BQMa4eAZiAbaACdbuqyAEi/yrwMQrp+A6JlasiJDq9r0eHYtnoLJ9f0JuiE+qUqNnR2IfRSwI3+MmIX4H65y3A=="
+    },
+    "node_modules/@0xsequence/chaind": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/chaind/-/chaind-0.21.5.tgz",
+      "integrity": "sha512-EI50j/I3PeijPy3eYaj/lRuy+SMwHZOeSew8UDihTm3/UKQ1tY7iyjK+zyWRYl6rGK8hO07I9PE7/0NLYUmaCA=="
+    },
+    "node_modules/@0xsequence/config": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/config/-/config-0.21.5.tgz",
+      "integrity": "sha512-hP+CZe1LQlCG6hwpV8l7Lip0vK8244amJ6dqCBGlxj+H7GR95+9c7g8DfZIKbQdY1VPJogvnHLvGBbUaSmZOzA==",
+      "dependencies": {
+        "@0xsequence/abi": "^0.21.5",
+        "@0xsequence/network": "^0.21.5",
+        "@0xsequence/utils": "^0.21.5",
+        "ethers": "^5.0.32"
+      }
+    },
+    "node_modules/@0xsequence/multicall": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/multicall/-/multicall-0.21.5.tgz",
+      "integrity": "sha512-E5o/LdVMbvUl62k/mgDfJmAVJ55FU3782ZUp2Pat3TOMNkgsUIk8e+j34WamMc+2kgw944WOOwG+wPzPb2D3Jg==",
+      "dependencies": {
+        "@0xsequence/abi": "^0.21.5",
+        "@0xsequence/network": "^0.21.5",
+        "@0xsequence/utils": "^0.21.5",
+        "@ethersproject/providers": "^5.0.24",
+        "ethers": "^5.0.32"
+      }
+    },
+    "node_modules/@0xsequence/network": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/network/-/network-0.21.5.tgz",
+      "integrity": "sha512-/Z7UJ0AqtggFyvtfhM9td+6EaEq9KePT5cK04dn7ZxncSa1yP7Nr5TfLynfK9w9wRL3OOmi144opoDnUi7Ib+A==",
+      "dependencies": {
+        "@0xsequence/utils": "^0.21.5",
+        "@ethersproject/providers": "^5.0.24",
+        "ethers": "^5.0.32"
+      }
+    },
+    "node_modules/@0xsequence/relayer": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/relayer/-/relayer-0.21.5.tgz",
+      "integrity": "sha512-yIrpZhzhxok1xMAu3cq7tFUmw1ftWjMU2SPKlcMNoSv7r7FE0Au5TROlmJvB0E7cQHosQFIX/rrJmdcElzHiFw==",
+      "dependencies": {
+        "@0xsequence/abi": "^0.21.5",
+        "@0xsequence/chaind": "^0.21.5",
+        "@0xsequence/config": "^0.21.5",
+        "@0xsequence/transactions": "^0.21.5",
+        "@0xsequence/utils": "^0.21.5",
+        "ethers": "^5.0.32",
+        "fetch-ponyfill": "^7.1.0"
+      }
+    },
+    "node_modules/@0xsequence/transactions": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/transactions/-/transactions-0.21.5.tgz",
+      "integrity": "sha512-T5Tgns84dNdsx2D+Ge+nAxrAX19/1oPVuNgIRYlT3JZd79Fs4GPtrdxN5K6iphcx1Ira0XeXg5Mmbq/E909QCw==",
+      "dependencies": {
+        "@0xsequence/abi": "^0.21.5",
+        "@0xsequence/chaind": "^0.21.5",
+        "@0xsequence/network": "^0.21.5",
+        "@0xsequence/utils": "^0.21.5",
+        "@ethersproject/abi": "^5.0.13",
+        "ethers": "^5.0.32"
+      }
+    },
+    "node_modules/@0xsequence/utils": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/utils/-/utils-0.21.5.tgz",
+      "integrity": "sha512-6gL0kot2o+E3n8E/1yvQR3wv4vxuJB9w25SNUK/zd9MDJ4oIY8tIy5jc4YrhQwC+FqKPG3k/8skNN9oP3gNXJg==",
+      "dependencies": {
+        "@ethersproject/abstract-signer": "5.0.14",
+        "@ethersproject/properties": "^5.0.9",
+        "ethers": "^5.0.32",
+        "js-base64": "^3.6.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5438,6 +5521,14 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-ponyfill": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-7.1.0.tgz",
+      "integrity": "sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==",
+      "dependencies": {
+        "node-fetch": "~2.6.1"
+      }
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -7110,6 +7201,11 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+    },
+    "node_modules/js-base64": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.6.1.tgz",
+      "integrity": "sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ=="
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
@@ -15440,6 +15536,87 @@
     }
   },
   "dependencies": {
+    "@0xsequence/abi": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/abi/-/abi-0.21.5.tgz",
+      "integrity": "sha512-BQMa4eAZiAbaACdbuqyAEi/yrwMQrp+A6JlasiJDq9r0eHYtnoLJ9f0JuiE+qUqNnR2IfRSwI3+MmIX4H65y3A=="
+    },
+    "@0xsequence/chaind": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/chaind/-/chaind-0.21.5.tgz",
+      "integrity": "sha512-EI50j/I3PeijPy3eYaj/lRuy+SMwHZOeSew8UDihTm3/UKQ1tY7iyjK+zyWRYl6rGK8hO07I9PE7/0NLYUmaCA=="
+    },
+    "@0xsequence/config": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/config/-/config-0.21.5.tgz",
+      "integrity": "sha512-hP+CZe1LQlCG6hwpV8l7Lip0vK8244amJ6dqCBGlxj+H7GR95+9c7g8DfZIKbQdY1VPJogvnHLvGBbUaSmZOzA==",
+      "requires": {
+        "@0xsequence/abi": "^0.21.5",
+        "@0xsequence/network": "^0.21.5",
+        "@0xsequence/utils": "^0.21.5",
+        "ethers": "^5.0.32"
+      }
+    },
+    "@0xsequence/multicall": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/multicall/-/multicall-0.21.5.tgz",
+      "integrity": "sha512-E5o/LdVMbvUl62k/mgDfJmAVJ55FU3782ZUp2Pat3TOMNkgsUIk8e+j34WamMc+2kgw944WOOwG+wPzPb2D3Jg==",
+      "requires": {
+        "@0xsequence/abi": "^0.21.5",
+        "@0xsequence/network": "^0.21.5",
+        "@0xsequence/utils": "^0.21.5",
+        "@ethersproject/providers": "^5.0.24",
+        "ethers": "^5.0.32"
+      }
+    },
+    "@0xsequence/network": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/network/-/network-0.21.5.tgz",
+      "integrity": "sha512-/Z7UJ0AqtggFyvtfhM9td+6EaEq9KePT5cK04dn7ZxncSa1yP7Nr5TfLynfK9w9wRL3OOmi144opoDnUi7Ib+A==",
+      "requires": {
+        "@0xsequence/utils": "^0.21.5",
+        "@ethersproject/providers": "^5.0.24",
+        "ethers": "^5.0.32"
+      }
+    },
+    "@0xsequence/relayer": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/relayer/-/relayer-0.21.5.tgz",
+      "integrity": "sha512-yIrpZhzhxok1xMAu3cq7tFUmw1ftWjMU2SPKlcMNoSv7r7FE0Au5TROlmJvB0E7cQHosQFIX/rrJmdcElzHiFw==",
+      "requires": {
+        "@0xsequence/abi": "^0.21.5",
+        "@0xsequence/chaind": "^0.21.5",
+        "@0xsequence/config": "^0.21.5",
+        "@0xsequence/transactions": "^0.21.5",
+        "@0xsequence/utils": "^0.21.5",
+        "ethers": "^5.0.32",
+        "fetch-ponyfill": "^7.1.0"
+      }
+    },
+    "@0xsequence/transactions": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/transactions/-/transactions-0.21.5.tgz",
+      "integrity": "sha512-T5Tgns84dNdsx2D+Ge+nAxrAX19/1oPVuNgIRYlT3JZd79Fs4GPtrdxN5K6iphcx1Ira0XeXg5Mmbq/E909QCw==",
+      "requires": {
+        "@0xsequence/abi": "^0.21.5",
+        "@0xsequence/chaind": "^0.21.5",
+        "@0xsequence/network": "^0.21.5",
+        "@0xsequence/utils": "^0.21.5",
+        "@ethersproject/abi": "^5.0.13",
+        "ethers": "^5.0.32"
+      }
+    },
+    "@0xsequence/utils": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@0xsequence/utils/-/utils-0.21.5.tgz",
+      "integrity": "sha512-6gL0kot2o+E3n8E/1yvQR3wv4vxuJB9w25SNUK/zd9MDJ4oIY8tIy5jc4YrhQwC+FqKPG3k/8skNN9oP3gNXJg==",
+      "requires": {
+        "@ethersproject/abstract-signer": "5.0.14",
+        "@ethersproject/properties": "^5.0.9",
+        "ethers": "^5.0.32",
+        "js-base64": "^3.6.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.11",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
@@ -19792,6 +19969,14 @@
         "reusify": "^1.0.4"
       }
     },
+    "fetch-ponyfill": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-7.1.0.tgz",
+      "integrity": "sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==",
+      "requires": {
+        "node-fetch": "~2.6.1"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -21062,6 +21247,11 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
       "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
+    },
+    "js-base64": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.6.1.tgz",
+      "integrity": "sha512-Frdq2+tRRGLQUIQOgsIGSCd1VePCS2fsddTG5dTCqR0JHgltXWfsxnY0gIXPoMeRmdom6Oyq+UMOFg5suduOjQ=="
     },
     "js-sha3": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.0.0-development",
   "main": "dist",
   "dependencies": {
+    "@0xsequence/multicall": "^0.21.5",
+    "@0xsequence/relayer": "^0.21.5",
     "@dcl/schemas": ">=1.1.0",
     "@types/flat": "0.0.28",
     "@types/node": "^10.1.2",

--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -121,7 +121,7 @@ export function createAuthorizationSaga(options?: AuthorizationSagaOptions) {
 
       const authorizationsToStore: Authorization[] = yield call(async () => {
         const results = await Promise.all(promises)
-        return results.filter(result => !!result) // filter nulls, or undefineds due to caughted promises
+        return results.filter(result => !!result) // filter nulls, or undefineds due to caught promises
       })
 
       yield put(fetchAuthorizationsSuccess(authorizationsToStore))

--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -86,6 +86,10 @@ export function createAuthorizationSaga(options?: AuthorizationSagaOptions) {
                 .then<Authorization | null>((allowance: BigNumber) =>
                   allowance.gt(0) ? authorization : null
                 )
+                .catch((error: Error) => {
+                  console.warn(`Error fetching allowance`, authorization, error)
+                  return null
+                })
             )
             break
           case AuthorizationType.APPROVAL:
@@ -106,6 +110,10 @@ export function createAuthorizationSaga(options?: AuthorizationSagaOptions) {
                 .then<Authorization | null>((isApproved: boolean) =>
                   isApproved ? authorization : null
                 )
+                .catch((error: Error) => {
+                  console.warn(`Error fetching approval`, authorization, error)
+                  return null
+                })
             )
             break
         }
@@ -113,7 +121,7 @@ export function createAuthorizationSaga(options?: AuthorizationSagaOptions) {
 
       const authorizationsToStore: Authorization[] = yield call(async () => {
         const results = await Promise.all(promises)
-        return results.filter(result => result !== null) // filter nulls
+        return results.filter(result => !!result) // filter nulls, or undefineds due to caughted promises
       })
 
       yield put(fetchAuthorizationsSuccess(authorizationsToStore))


### PR DESCRIPTION
I had to refactor the saga to use `ethers` instead of `web3x` because it didn't get along with the multicall provider. I didn't have to install `ethers` tho because it was already a dependency of other dependencies in the project.

I had to install also `@0xsequence/relayer` because otherwise the build would fail, although it's not explicitly imported in the code (it's an undocumented peer dependency of `@0xsequence/multicall`

I tested this as a release candidate `decentraland-dapps@12.10.0-rc7` installed in the marketplace using the production `.env` vars.