### PR TITLE
fix: Avatar description update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "12.16.0-rc1",
+  "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1496,6 +1496,15 @@
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
+    },
+    "@types/ramda": {
+      "version": "0.27.44",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.44.tgz",
+      "integrity": "sha512-SlEHKcLG36PlU+rLJwp8p4dpC9Hp/LiH6n0REX2m4iEB15PWe1qKQzgNSZrYKhTHDFvkeEM/F2gcYwfighsEuQ==",
+      "dev": true,
+      "requires": {
+        "ts-toolbelt": "^6.15.1"
+      }
     },
     "@types/react": {
       "version": "16.14.6",
@@ -9607,6 +9616,12 @@
         "performance-now": "^2.1.0"
       }
     },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -11178,6 +11193,12 @@
           "dev": true
         }
       }
+    },
+    "ts-toolbelt": {
+      "version": "6.15.5",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==",
+      "dev": true
     },
     "tslib": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.4",
     "@types/mocha": "^5.2.5",
+    "@types/ramda": "^0.27.44",
     "chai": "^4.1.2",
     "dcl-tslint-config-standard": "^1.0.1",
     "esm": "^3.2.25",
@@ -50,6 +51,7 @@
     "mocha": "^5.2.0",
     "nyc": "^15.1.0",
     "prettier": "^1.10.2",
+    "ramda": "^0.27.1",
     "react": "^17.0.2",
     "react-redux": "^7.2.4",
     "redux": "^4.1.0",

--- a/src/modules/profile/actions.spec.ts
+++ b/src/modules/profile/actions.spec.ts
@@ -19,6 +19,8 @@ import {
 
 const address = 'anAddress'
 const error = 'anErrorMessage'
+const description = 'aDescription'
+const version = 1234
 
 describe('when creating the action to clear the profile error', () => {
   it('should return an object representing the action', () => {
@@ -86,10 +88,12 @@ describe("when creating the action to signal a failure in the request to set the
 
 describe("when creating the action to signal a successful request to set the description of a profile's avatar", () => {
   it('should return an object representing the action', () => {
-    expect(setProfileAvatarDescriptionSuccess(address, profile)).deep.equals({
+    expect(
+      setProfileAvatarDescriptionSuccess(address, description, version)
+    ).deep.equals({
       type: SET_PROFILE_AVATAR_DESCRIPTION_SUCCESS,
       meta: undefined,
-      payload: { address, profile }
+      payload: { address, description, version }
     })
   })
 })

--- a/src/modules/profile/actions.ts
+++ b/src/modules/profile/actions.ts
@@ -33,8 +33,14 @@ export const setProfileAvatarDescriptionRequest = (
 ) => action(SET_PROFILE_AVATAR_DESCRIPTION_REQUEST, { address, description })
 export const setProfileAvatarDescriptionSuccess = (
   address: string,
-  profile: Profile
-) => action(SET_PROFILE_AVATAR_DESCRIPTION_SUCCESS, { address, profile })
+  description: string,
+  version: number
+) =>
+  action(SET_PROFILE_AVATAR_DESCRIPTION_SUCCESS, {
+    address,
+    description,
+    version
+  })
 export const setProfileAvatarDescriptionFailure = (
   address: string,
   error: string

--- a/src/modules/profile/reducer.spec.ts
+++ b/src/modules/profile/reducer.spec.ts
@@ -15,6 +15,8 @@ import { loadingReducer } from '../loading/reducer'
 
 const address = 'anAddress'
 const error = 'anError'
+const description = 'aDescription'
+const version = 1234
 
 const requestActions = [
   setProfileAvatarDescriptionRequest(address, 'aDescription'),
@@ -68,33 +70,62 @@ failureActions.forEach(action => {
   })
 })
 
-const successActions = [
-  {
-    request: setProfileAvatarDescriptionRequest(address, 'aDescription'),
-    success: setProfileAvatarDescriptionSuccess(address, profile)
-  },
-  {
-    request: loadProfileRequest(address),
-    success: loadProfileSuccess(address, profile)
-  }
-]
+describe('when reducing the action that signals a successful profile load', () => {
+  it('should return a state with the profile set and the loading state cleared', () => {
+    const request = loadProfileRequest(address)
+    const success = loadProfileSuccess(address, profile)
+    const initialState = {
+      ...INITIAL_STATE,
+      loading: loadingReducer([], request)
+    }
 
-successActions.forEach(action => {
-  describe(`when reducing the "${action.success.type}" action`, () => {
-    it('should return a state with the profile set and the loading state cleared', () => {
-      const initialState = {
-        ...INITIAL_STATE,
-        loading: loadingReducer([], action.request)
+    expect(profileReducer(initialState, success)).deep.equals({
+      ...INITIAL_STATE,
+      loading: [],
+      data: {
+        ...initialState.data,
+        [address]: profile
       }
+    })
+  })
+})
 
-      expect(profileReducer(initialState, action.success)).deep.equals({
-        ...INITIAL_STATE,
-        loading: [],
-        data: {
-          ...initialState.data,
-          [address]: profile
+describe('when reducing the action that signals a successful profile avatar description change', () => {
+  it('should return a state with the avatar description and version changed and the loading state cleared', () => {
+    const request = setProfileAvatarDescriptionRequest(address, description)
+    const success = setProfileAvatarDescriptionSuccess(
+      address,
+      description,
+      version
+    )
+    const initialState = {
+      ...INITIAL_STATE,
+      data: {
+        ...INITIAL_STATE.data,
+        [address]: profile
+      },
+      loading: loadingReducer([], request)
+    }
+
+    const expectedAvatar = {
+      ...initialState.data[address].avatars[0],
+      version,
+      description
+    }
+
+    expect(profileReducer(initialState, success)).deep.equals({
+      ...initialState,
+      loading: [],
+      data: {
+        ...initialState.data,
+        [address]: {
+          ...profile,
+          avatars: [
+            expectedAvatar,
+            ...initialState.data[address].avatars.slice(1)
+          ]
         }
-      })
+      }
     })
   })
 })

--- a/src/modules/profile/reducer.ts
+++ b/src/modules/profile/reducer.ts
@@ -62,7 +62,26 @@ export const profileReducer = (
         error: action.payload.error
       }
     }
-    case SET_PROFILE_AVATAR_DESCRIPTION_SUCCESS:
+    case SET_PROFILE_AVATAR_DESCRIPTION_SUCCESS: {
+      const { address, description, version } = action.payload
+      const newAvatar = {
+        ...state.data[address].avatars[0],
+        description,
+        version
+      }
+
+      return {
+        ...state,
+        data: {
+          ...state.data,
+          [address]: {
+            ...state.data[address],
+            avatars: [newAvatar, ...state.data[address].avatars.slice(1)]
+          }
+        },
+        loading: loadingReducer(state.loading, action)
+      }
+    }
     case LOAD_PROFILE_SUCCESS: {
       const { address, profile } = action.payload
       return {

--- a/src/modules/profile/sagas.spec.ts
+++ b/src/modules/profile/sagas.spec.ts
@@ -54,7 +54,7 @@ describe('when handling the action to set the profile avatar description', () =>
   })
 
   describe('when the deployment is successful', () => {
-    it.only('should deploy the new entity with the decription and the version changed', () => {
+    it('should deploy the new entity with the decription and the version changed', () => {
       const newAvatar = {
         ...profileEntity.metadata.avatars[0],
         version: profileEntity.metadata.avatars[0].version + 1,

--- a/src/modules/profile/sagas.ts
+++ b/src/modules/profile/sagas.ts
@@ -90,7 +90,6 @@ export function createProfileSaga({ peerUrl }: CreateProfileSagaOptions) {
           avatars: [newAvatar, ...entity.metadata.avatars.slice(1)]
         }
       }
-
       yield call(
         [entities, 'deployEntityWithoutNewFiles'],
         newEntity,
@@ -101,7 +100,8 @@ export function createProfileSaga({ peerUrl }: CreateProfileSagaOptions) {
       yield put(
         setProfileAvatarDescriptionSuccess(
           action.payload.address,
-          newEntity.metadata
+          newAvatar.description,
+          newAvatar.version
         )
       )
     } catch (error) {

--- a/src/tests/sagas.ts
+++ b/src/tests/sagas.ts
@@ -1,0 +1,11 @@
+import { dynamic } from 'redux-saga-test-plan/providers'
+import * as R from 'ramda'
+
+export function dynamicDeepParametersEquality(
+  parameters: Array<unknown>,
+  returnValue: unknown
+) {
+  return dynamic(({ args }, next) =>
+    R.equals(args, parameters) ? Promise.resolve(returnValue) : next()
+  )
+}


### PR DESCRIPTION
This PR changes the way that the profile is updated after a description change in an avatar.
The idea of this change is to re-use the information we already have without the need of doing another request to the profile lambda endpoint.