### PR TITLE
feat: handle unknown networks

### DIFF
--- a/src/containers/ChainCheck/ChainCheck.tsx
+++ b/src/containers/ChainCheck/ChainCheck.tsx
@@ -1,9 +1,11 @@
 import React from 'react'
 import { Popup } from 'decentraland-ui'
 import { T } from '../../modules/translation/utils'
-import { getConnectedProviderChainId } from '../../lib/eth'
+import {
+  getConnectedProviderChainId,
+  getNetworkNameByChainId
+} from '../../lib/eth'
 import { Props } from './ChainCheck.types'
-import { getChainName } from '@dcl/schemas'
 import ChainProvider from '../ChainProvider'
 
 export default class ChainCheck extends React.PureComponent<Props> {
@@ -22,7 +24,11 @@ export default class ChainCheck extends React.PureComponent<Props> {
                   id="@dapps.button.network_not_supported"
                   values={{
                     expectedChainName: (
-                      <b>{getChainName(getConnectedProviderChainId()!)}</b>
+                      <b>
+                        {getNetworkNameByChainId(
+                          getConnectedProviderChainId()!
+                        )}
+                      </b>
                     )
                   }}
                 />

--- a/src/containers/Navbar/Navbar.tsx
+++ b/src/containers/Navbar/Navbar.tsx
@@ -6,8 +6,10 @@ import {
   Navbar as NavbarComponent,
   NavbarI18N
 } from 'decentraland-ui'
-import { getChainName } from '@dcl/schemas'
-import { getConnectedProviderChainId } from '../../lib/eth'
+import {
+  getConnectedProviderChainId,
+  getNetworkNameByChainId
+} from '../../lib/eth'
 import { T } from '../../modules/translation/utils'
 import Modal from '../../containers/Modal'
 import { NavbarProps, NavbarState } from './Navbar.types'
@@ -51,7 +53,9 @@ export default class Navbar extends React.PureComponent<
   }
 
   render() {
-    const expectedChainName = getChainName(getConnectedProviderChainId()!)
+    const expectedChainName = getNetworkNameByChainId(
+      getConnectedProviderChainId()!
+    )
     return (
       <>
         <NavbarComponent {...this.props} i18n={this.getTranslations()} />
@@ -66,7 +70,9 @@ export default class Navbar extends React.PureComponent<
                   <T
                     id="@dapps.navbar.wrong_network.message"
                     values={{
-                      currentChainName: <b>{getChainName(chainId!)}</b>,
+                      currentChainName: (
+                        <b>{getNetworkNameByChainId(chainId!)}</b>
+                      ),
                       expectedChainName: <b>{expectedChainName}</b>
                     }}
                   />
@@ -93,7 +99,9 @@ export default class Navbar extends React.PureComponent<
                   <T
                     id="@dapps.navbar.partially_supported_network.message"
                     values={{
-                      currentChainName: <b>{getChainName(chainId!)}</b>,
+                      currentChainName: (
+                        <b>{getNetworkNameByChainId(chainId!)}</b>
+                      ),
                       expectedChainName: <b>{expectedChainName}</b>
                     }}
                   />
@@ -114,7 +122,7 @@ export default class Navbar extends React.PureComponent<
                     <T
                       id="@dapps.navbar.partially_supported_network.continue_button"
                       values={{
-                        chainName: <b>{getChainName(chainId!)}</b>
+                        chainName: <b>{getNetworkNameByChainId(chainId!)}</b>
                       }}
                     />
                   </Button>

--- a/src/lib/eth.ts
+++ b/src/lib/eth.ts
@@ -1,4 +1,4 @@
-import { ChainId, Network } from '@dcl/schemas'
+import { ChainId, getChainName, Network } from '@dcl/schemas'
 import { providers } from 'ethers'
 import { connection, ProviderType, Provider } from 'decentraland-connect'
 import { getChainConfiguration } from './chainConfiguration'
@@ -69,4 +69,14 @@ export function getChainIdByNetwork(network: Network) {
   }
   const config = getChainConfiguration(connectedChainId)
   return config.networkMapping[network]
+}
+
+export function getNetworkName(network: Network) {
+  const chainId = getChainIdByNetwork(network)
+  return getNetworkNameByChainId(chainId)
+}
+
+export function getNetworkNameByChainId(chainId: ChainId) {
+  const name = getChainName(chainId)
+  return name || `Unknown Network (chainId=${chainId})`
 }

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -8,12 +8,13 @@ import {
   sendMetaTransaction
 } from 'decentraland-transactions'
 import { Provider } from 'decentraland-connect'
-import { ChainId, getChainName } from '@dcl/schemas'
+import { ChainId } from '@dcl/schemas'
 import { PopulatedTransaction, Contract, providers, utils } from 'ethers'
 import {
   getConnectedProvider,
   getConnectedProviderChainId,
   getConnectedProviderType,
+  getNetworkNameByChainId,
   getNetworkProvider
 } from '../../lib/eth'
 import { getChainConfiguration } from '../../lib/chainConfiguration'
@@ -152,7 +153,7 @@ export function getAddEthereumChainParameters(
   chainId: ChainId
 ): AddEthereumChainParameters {
   const hexChainId = '0x' + chainId.toString(16)
-  const chainName = getChainName(chainId)!
+  const chainName = getNetworkNameByChainId(chainId)
   const config = getChainConfiguration(chainId)
   switch (chainId) {
     case ChainId.MATIC_MAINNET:


### PR DESCRIPTION
Added a few helpers to get the network name (either by `Network` or `ChainId`). 

```ts
getNetworkName(network: Network): string
getNetworkNameByChainId(chainId: ChainId): string
```

If the network is not part of our `Network` enum, it will return `Unknown Network (chainId=XX)`. I didn't add this functionality into the `getChainName` helper from `@dcl/schemas` because I didn't want to change the signature, which returns a `ChainName | null`, whereas these helpers return always `string`.

The idea behind this is to avoid the issue described on this comment: https://github.com/decentraland/account/pull/142#pullrequestreview-736478735 