### PR TITLE
fix: keep partial support modal closed

### DIFF
--- a/src/containers/Navbar/Navbar.container.tsx
+++ b/src/containers/Navbar/Navbar.container.tsx
@@ -4,10 +4,14 @@ import {
   isConnecting,
   getAddress,
   getMana,
-  getChainId
+  getChainId,
+  hasAcceptedNetworkPartialSupport
 } from '../../modules/wallet/selectors'
 import { isEnabled } from '../../modules/translation/selectors'
-import { switchNetworkRequest } from '../../modules/wallet/actions'
+import {
+  acceptNetworkPartialSupport,
+  switchNetworkRequest
+} from '../../modules/wallet/actions'
 import { RootDispatch } from '../../types'
 import { NavbarProps, MapStateProps, MapDispatchProps } from './Navbar.types'
 import Navbar from './Navbar'
@@ -18,11 +22,13 @@ const mapState = (state: any): MapStateProps => ({
   address: getAddress(state),
   isConnected: isConnected(state),
   isConnecting: isConnecting(state),
-  hasTranslations: isEnabled(state)
+  hasTranslations: isEnabled(state),
+  hasAcceptedNetworkPartialSupport: hasAcceptedNetworkPartialSupport(state)
 })
 
 const mapDispatch = (dispatch: RootDispatch): MapDispatchProps => ({
-  onSwitchNetwork: chainId => dispatch(switchNetworkRequest(chainId))
+  onSwitchNetwork: chainId => dispatch(switchNetworkRequest(chainId)),
+  onAcceptNetworkPartialSupport: () => dispatch(acceptNetworkPartialSupport())
 })
 
 const mergeProps = (

--- a/src/containers/Navbar/Navbar.tsx
+++ b/src/containers/Navbar/Navbar.tsx
@@ -11,17 +11,9 @@ import { getConnectedProviderChainId } from '../../lib/eth'
 import { T } from '../../modules/translation/utils'
 import Modal from '../../containers/Modal'
 import ChainProvider from '../ChainProvider'
-import { NavbarProps, NavbarState } from './Navbar.types'
-import { acceptPartialSupport, isPartialSupportAccepted } from './utils'
+import { NavbarProps } from './Navbar.types'
 
-export default class Navbar extends React.PureComponent<
-  NavbarProps,
-  NavbarState
-> {
-  state: NavbarState = {
-    isPartialSupportModalOpen: !isPartialSupportAccepted()
-  }
-
+export default class Navbar extends React.PureComponent<NavbarProps> {
   getTranslations = (): NavbarI18N | undefined => {
     if (!this.props.hasTranslations) {
       return undefined
@@ -43,16 +35,15 @@ export default class Navbar extends React.PureComponent<
     }
   }
 
-  handleClosePartialSupportModal = () => {
-    this.setState({ isPartialSupportModalOpen: false })
-    acceptPartialSupport()
-  }
-
   handleSwitchNetwork = () => {
     this.props.onSwitchNetwork(getConnectedProviderChainId()!)
   }
 
   render() {
+    const {
+      hasAcceptedNetworkPartialSupport,
+      onAcceptNetworkPartialSupport
+    } = this.props
     const expectedChainName = getChainName(getConnectedProviderChainId()!)
     return (
       <>
@@ -94,7 +85,7 @@ export default class Navbar extends React.PureComponent<
                 </Modal.Actions>
               </Modal>
             ) : isPartiallySupported ? (
-              <Modal open={this.state.isPartialSupportModalOpen} size="tiny">
+              <Modal open={!hasAcceptedNetworkPartialSupport} size="tiny">
                 <ModalNavigation
                   title={
                     <T id="@dapps.navbar.partially_supported_network.header" />
@@ -118,10 +109,7 @@ export default class Navbar extends React.PureComponent<
                       }}
                     />
                   </Button>
-                  <Button
-                    secondary
-                    onClick={this.handleClosePartialSupportModal}
-                  >
+                  <Button secondary onClick={onAcceptNetworkPartialSupport}>
                     <T
                       id="@dapps.navbar.partially_supported_network.continue_button"
                       values={{

--- a/src/containers/Navbar/Navbar.types.tsx
+++ b/src/containers/Navbar/Navbar.types.tsx
@@ -2,6 +2,8 @@ import { Dispatch } from 'redux'
 import { ChainId } from '@dcl/schemas'
 import { NavbarProps as NavbarComponentProps } from 'decentraland-ui'
 import {
+  acceptNetworkPartialSupport,
+  AcceptNetworkPartialSupportAction,
   switchNetworkRequest,
   SwitchNetworkRequestAction
 } from '../../modules/wallet/actions'
@@ -10,10 +12,8 @@ export type NavbarProps = NavbarComponentProps & {
   chainId?: ChainId
   hasTranslations?: boolean
   onSwitchNetwork: typeof switchNetworkRequest
-}
-
-export type NavbarState = {
-  isPartialSupportModalOpen: boolean
+  hasAcceptedNetworkPartialSupport: boolean
+  onAcceptNetworkPartialSupport: typeof acceptNetworkPartialSupport
 }
 
 export type MapStateProps = Pick<
@@ -24,7 +24,13 @@ export type MapStateProps = Pick<
   | 'isConnecting'
   | 'hasTranslations'
   | 'chainId'
+  | 'hasAcceptedNetworkPartialSupport'
 >
 
-export type MapDispatchProps = Pick<NavbarProps, 'onSwitchNetwork'>
-export type MapDispatch = Dispatch<SwitchNetworkRequestAction>
+export type MapDispatchProps = Pick<
+  NavbarProps,
+  'onSwitchNetwork' | 'onAcceptNetworkPartialSupport'
+>
+export type MapDispatch = Dispatch<
+  SwitchNetworkRequestAction | AcceptNetworkPartialSupportAction
+>

--- a/src/containers/Navbar/utils.ts
+++ b/src/containers/Navbar/utils.ts
@@ -1,7 +1,0 @@
-let accepted = false
-export function isPartialSupportAccepted() {
-  return accepted
-}
-export function acceptPartialSupport() {
-  accepted = true
-}

--- a/src/modules/wallet/actions.ts
+++ b/src/modules/wallet/actions.ts
@@ -74,3 +74,10 @@ export const switchNetworkFailure = (chainId: ChainId, error: string) =>
 export type SwitchNetworkRequestAction = ReturnType<typeof switchNetworkRequest>
 export type SwitchNetworkSuccessAction = ReturnType<typeof switchNetworkSuccess>
 export type SwitchNetworkFailureAction = ReturnType<typeof switchNetworkFailure>
+
+export const ACCEPT_NETWORK_PARTIAL_SUPPORT = 'Accept network partial support'
+export const acceptNetworkPartialSupport = () =>
+  action(ACCEPT_NETWORK_PARTIAL_SUPPORT)
+export type AcceptNetworkPartialSupportAction = ReturnType<
+  typeof acceptNetworkPartialSupport
+>

--- a/src/modules/wallet/reducer.ts
+++ b/src/modules/wallet/reducer.ts
@@ -25,19 +25,23 @@ import {
   FetchWalletSuccessAction,
   FetchWalletFailureAction,
   FETCH_WALLET_SUCCESS,
-  FETCH_WALLET_FAILURE
+  FETCH_WALLET_FAILURE,
+  AcceptNetworkPartialSupportAction,
+  ACCEPT_NETWORK_PARTIAL_SUPPORT
 } from './actions'
 
 export type WalletState = {
   data: Wallet | null
   loading: LoadingState
   error: string | null
+  hasAcceptedNetworkPartialSupport: boolean
 }
 
 export const INITIAL_STATE: WalletState = {
   data: null,
   loading: [],
-  error: null
+  error: null,
+  hasAcceptedNetworkPartialSupport: false
 }
 
 export type WalletReducerAction =
@@ -53,6 +57,7 @@ export type WalletReducerAction =
   | FetchWalletRequestAction
   | FetchWalletSuccessAction
   | FetchWalletFailureAction
+  | AcceptNetworkPartialSupportAction
 
 export function walletReducer(
   state: WalletState = INITIAL_STATE,
@@ -90,7 +95,8 @@ export function walletReducer(
       return {
         ...state,
         loading: loadingReducer(state.loading, action),
-        error: null
+        error: null,
+        hasAcceptedNetworkPartialSupport: false
       }
     }
 
@@ -102,12 +108,20 @@ export function walletReducer(
       }
     }
 
-    case CHANGE_ACCOUNT:
-    case CHANGE_NETWORK: {
+    case CHANGE_ACCOUNT: {
       return {
         ...state,
         error: null,
         data: action.payload.wallet
+      }
+    }
+
+    case CHANGE_NETWORK: {
+      return {
+        ...state,
+        error: null,
+        data: action.payload.wallet,
+        hasAcceptedNetworkPartialSupport: false
       }
     }
 
@@ -116,6 +130,13 @@ export function walletReducer(
         ...state,
         error: null,
         data: null
+      }
+    }
+
+    case ACCEPT_NETWORK_PARTIAL_SUPPORT: {
+      return {
+        ...state,
+        hasAcceptedNetworkPartialSupport: true
       }
     }
 

--- a/src/modules/wallet/selectors.ts
+++ b/src/modules/wallet/selectors.ts
@@ -29,6 +29,9 @@ export const getNetwork = (state: any) =>
 export const getNetworks = (state: any) =>
   isConnected(state) ? getData(state)!.networks : undefined
 
+export const hasAcceptedNetworkPartialSupport = (state: any) =>
+  getState(state).hasAcceptedNetworkPartialSupport
+
 /**
  * @deprecated This method is deprecated, it only returns the MANA balance on Ethereum, use getNetworks() to get the MANA balances on all the networks.
  */


### PR DESCRIPTION
Since the boolean to keep the modal closed was stored in the component's state, it would show up again if the `Navbar` was unmounted and mounted again. 

I didn't realize this before since the Account dapp has a single page, but the other dapps have some states where the Navbar is unmounted and the modal becomes very annoying.