### PR TITLE
feat: use native tx helper for authorizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,7 @@ This module allows you to grant/revoke approvals to a token. It works for both a
 
 ### Dependencies
 
-This module depends on the [transactions](#transactions) module
+This module depends on the [wallet](#wallet) and the [transactions](#transactions) module
 
 ### Usage
 
@@ -582,16 +582,11 @@ export const rootReducer = combineReducers({
 
 **Sagas**
 
-Use `createAuthorizationSaga` and add the returned saga to the `rootSaga`. Alternatively, if you are just going to use this module on Ethereum (which means you won't need meta-transactions) you can just import `authorizationSaga`:
+Add the `authorizationSaga` to the `rootSaga`:
 
 ```ts
 import { all } from 'redux-saga/effects'
-import { createAuthorizationSaga } from 'decentraland-dapps/dist/modules/authorization/sagas'
-
-// if you are not going to use meta transactions you can skip the options or just import `authorizationSaga`
-const authorizationSaga = createAuthorizationSaga({
-  metaTransactionServerUrl: 'https://transactions-api.decentraland.io'
-})
+import { authorizationSaga } from 'decentraland-dapps/dist/modules/authorization/sagas'
 
 export function* rootSaga() {
   yield all([

--- a/src/modules/authorization/types.ts
+++ b/src/modules/authorization/types.ts
@@ -19,7 +19,3 @@ export type Authorization = {
   contractName: ContractName
   chainId: ChainId
 }
-
-export type AuthorizationSagaOptions = {
-  metaTransactionServerUrl?: string
-}


### PR DESCRIPTION
This PR uses the `sendTransaction` helper in the `authorization` module so users can grant authorizations on other networks using native transactions