### PR TITLE
fix: Save the latest migration version when nothing is in storage

### DIFF
--- a/src/lib/localStorage.spec.ts
+++ b/src/lib/localStorage.spec.ts
@@ -2,7 +2,8 @@ import { Migrations } from './types'
 import {
   hasLocalStorage,
   migrateStorage,
-  getLocalStorage
+  getLocalStorage,
+  getDefaultState
 } from './localStorage'
 declare var global: any
 let fakeStore = {}
@@ -62,6 +63,28 @@ describe('localStorage', function() {
 
       data = migrateStorage(key, migrations)
       expect(data.storage.version).toBe(2)
+    })
+  })
+
+  describe('getDefaultState', function() {
+    it('should return 1 when no migrations are provided', function() {
+      const state = getDefaultState({})
+      expect(state).toEqual({ storage: { version: 1 } })
+    })
+
+    it('should return the migration key as version if there is only one', function() {
+      const state = getDefaultState({ '2': () => {} })
+      expect(state).toEqual({ storage: { version: 2 } })
+    })
+
+    it('should return the highest migration version if there is more than one', function() {
+      const state = getDefaultState({ '2': () => {}, '3': () => {} })
+      expect(state).toEqual({ storage: { version: 3 } })
+    })
+
+    it('should ignore migrations with keys that are not numbers', function() {
+      const state = getDefaultState({ '2': () => {}, foo: () => {} })
+      expect(state).toEqual({ storage: { version: 2 } })
     })
   })
 })

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -1,4 +1,4 @@
-import { Migrations, LocalStorage } from './types'
+import { Migrations, LocalStorage, StorageOwnData } from './types'
 
 export function hasLocalStorage(): boolean {
   try {
@@ -23,10 +23,24 @@ export function getLocalStorage(): LocalStorage {
       }
 }
 
-export function migrateStorage<T>(
+function getDefaultState<T>(migrations: Migrations<T>) {
+  const keys = Object.keys(migrations)
+
+  const version =
+    keys.length === 0
+      ? 1
+      : Object.keys(migrations)
+          .map(Number)
+          .filter(num => !isNaN(num))
+          .sort((a, b) => (b - a ? 1 : 0))[0]
+
+  return { storage: { version } }
+}
+
+export function migrateStorage<T extends StorageOwnData>(
   key: string,
   migrations: Migrations<T>
-): T | null {
+): T {
   let version = 1
   const localStorage = getLocalStorage()
   const dataString = localStorage.getItem(key)
@@ -51,5 +65,5 @@ export function migrateStorage<T>(
     return data
   }
 
-  return null
+  return getDefaultState(migrations) as T
 }

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -23,7 +23,7 @@ export function getLocalStorage(): LocalStorage {
       }
 }
 
-function getDefaultState<T>(migrations: Migrations<T>) {
+export function getDefaultState<T>(migrations: Migrations<T>) {
   const keys = Object.keys(migrations)
 
   const version =
@@ -32,7 +32,7 @@ function getDefaultState<T>(migrations: Migrations<T>) {
       : Object.keys(migrations)
           .map(Number)
           .filter(num => !isNaN(num))
-          .sort((a, b) => (b - a ? 1 : 0))[0]
+          .sort((a, b) => b - a)[0]
 
   return { storage: { version } }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -35,3 +35,9 @@ export interface LocalStorage {
   setItem: (key?: string, value?: string) => void | null
   removeItem: (key?: string) => void | null
 }
+
+export type StorageOwnData = {
+  storage: {
+    version: number
+  }
+}

--- a/src/modules/storage/middleware.ts
+++ b/src/modules/storage/middleware.ts
@@ -4,6 +4,7 @@ import createStorageEngine from 'redux-persistence-engine-localstorage'
 import filter from 'redux-storage-decorator-filter'
 import { hasLocalStorage, migrateStorage } from '../../lib/localStorage'
 import { disabledMiddleware } from '../../lib/disabledMiddleware'
+import { StorageOwnData } from '../../lib/types'
 import { STORAGE_LOAD } from './actions'
 import { StorageMiddleware } from './types'
 import {
@@ -25,7 +26,9 @@ import {
 const disabledLoad = (store: any) =>
   setTimeout(() => store.dispatch({ type: STORAGE_LOAD, payload: {} }))
 
-export function createStorageMiddleware<T>(options: StorageMiddleware<T>) {
+export function createStorageMiddleware<T extends StorageOwnData>(
+  options: StorageMiddleware<T>
+) {
   const { storageKey, migrations = {}, paths = [], actions = [] } = options
 
   if (!hasLocalStorage()) {
@@ -38,13 +41,11 @@ export function createStorageMiddleware<T>(options: StorageMiddleware<T>) {
   const localStorageState = migrateStorage(storageKey, migrations)
   let setItemFailure = false
 
-  if (localStorageState) {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(localStorageState))
-    } catch (e) {
-      setItemFailure = true
-      console.warn(e.message)
-    }
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(localStorageState))
+  } catch (e) {
+    setItemFailure = true
+    console.warn(e.message)
   }
 
   const storageEngine = filter(createStorageEngine(storageKey), [


### PR DESCRIPTION
Fixes #183 

The first time an app using the storage middleware is loaded. The state will be stored with version 1 even if there are multiple migrations defined. This might bring issues because, for example: 

Imagine I have an app with 4 migrations. The first time I load the app and do thing on it, state will be stored with the current schema which is supposed to be version 4. However, it is tagged with version 1, causing the next session to try to execute migrations over up to date objects.