### PR TITLE
feat: Make send transaction testable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 .nyc_output
 coverage
+.vscode

--- a/src/modules/wallet/utils.spec.ts
+++ b/src/modules/wallet/utils.spec.ts
@@ -1,0 +1,223 @@
+import { ContractData, sendMetaTransaction } from 'decentraland-transactions'
+import { providers } from 'ethers'
+import { getConnectedProvider, getNetworkProvider } from '../../lib/eth'
+import {
+  mockedContract,
+  buildMockedNetworkProvider
+} from '../../tests/transactions'
+import { getTransactionsApiUrl, sendTransaction } from './utils'
+
+jest.mock('../../lib/eth')
+jest.mock('decentraland-transactions')
+const mockedGetConnectedProvider: jest.Mock<typeof getConnectedProvider> = getConnectedProvider as any
+const mockedGetNetworkProvider: jest.Mock<typeof getNetworkProvider> = getNetworkProvider as any
+const mockedSendMetaTransaction: jest.Mock<typeof sendMetaTransaction> = sendMetaTransaction as any
+
+type MockedProvider = {
+  request: jest.Mock
+}
+
+let contract: ContractData
+
+describe('when sending a transaction', () => {
+  let error: Error
+  const transactionHash =
+    '0xc9dd675b8949ce5d18b6cb4c9df888bb4c37ca02bbe54eb42d2b42514a0967c5'
+
+  beforeEach(() => {
+    contract = { ...mockedContract }
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("and the connected provided couldn't be retrieved", () => {
+    beforeEach(() => {
+      error = new Error('Could not get provider')
+      mockedGetConnectedProvider.mockRejectedValueOnce(error as never)
+    })
+
+    it('should throw an error signaling that the provider is not connected', () => {
+      return expect(
+        sendTransaction(contract, 'totalSupply')
+      ).rejects.toThrowError(error.message)
+    })
+  })
+
+  describe("and the current chain id couldn't be retrieved", () => {
+    beforeEach(() => {
+      error = new Error('Could not get chain id')
+      mockedGetConnectedProvider.mockResolvedValueOnce({
+        request: jest.fn().mockRejectedValueOnce(error)
+      } as never)
+    })
+
+    it('should throw an error signaling that it was not able to get the chain id', () => {
+      return expect(
+        sendTransaction(contract, 'totalSupply')
+      ).rejects.toThrowError(error.message)
+    })
+  })
+
+  describe("and the target network provided couldn't be retrieved", () => {
+    beforeEach(() => {
+      error = new Error('Could not get the network provider')
+      const connectedNetworkProvider = buildMockedNetworkProvider()
+      mockedGetConnectedProvider.mockResolvedValueOnce(
+        connectedNetworkProvider as never
+      )
+      mockedGetNetworkProvider.mockRejectedValueOnce(error as never)
+    })
+
+    it('should throw an error signaling that it was not able to get the network provider', () => {
+      return expect(
+        sendTransaction(contract, 'totalSupply')
+      ).rejects.toThrowError(error.message)
+    })
+  })
+
+  describe("and the current chain id is the same as the contract's chain id", () => {
+    describe('and the transaction fails to be sent', () => {
+      beforeEach(() => {
+        error = new Error('Transaction failed to be sent')
+        const networkProvider = {
+          request: ({ method }: { method: string }) => {
+            switch (method) {
+              case 'eth_chainId':
+                return Promise.resolve('0x13881')
+              case 'eth_accounts':
+                return Promise.resolve([
+                  '0x7309F0134f3e51E8CBE29dD86068e0F264F6c946'
+                ])
+              case 'eth_estimateGas':
+                return Promise.resolve('0x5208')
+              case 'eth_sendTransaction':
+                return Promise.reject(error)
+              default:
+                throw new Error(`Unexpected method ${method}`)
+            }
+          }
+        }
+
+        const connectedNetworkProvider = buildMockedNetworkProvider({
+          ethChainId: Promise.resolve('0x13881')
+        })
+
+        mockedGetNetworkProvider.mockResolvedValue(networkProvider as never)
+        mockedGetConnectedProvider.mockResolvedValue(
+          connectedNetworkProvider as never
+        )
+      })
+
+      it('should throw an error signaling that it was not able to send the transaction', () => {
+        return expect(sendTransaction(contract, 'totalSupply')).rejects.toThrow(
+          error.message
+        )
+      })
+    })
+
+    describe('and the transaction is sent successfully', () => {
+      let networkProvider: MockedProvider
+
+      beforeEach(() => {
+        networkProvider = buildMockedNetworkProvider({
+          ethSendTransaction: Promise.resolve(transactionHash)
+        })
+
+        const connectedNetworkProvider = buildMockedNetworkProvider({
+          ethChainId: Promise.resolve('0x13881')
+        })
+
+        mockedGetNetworkProvider.mockResolvedValue(networkProvider as never)
+        mockedGetConnectedProvider.mockResolvedValue(
+          connectedNetworkProvider as never
+        )
+      })
+
+      it('should resolve with the transaction hash', () => {
+        return expect(
+          sendTransaction(contract, 'totalSupply')
+        ).resolves.toEqual(transactionHash)
+      })
+
+      it('should have sent the transaction with the populated data', async () => {
+        await sendTransaction(contract, 'totalSupply')
+        expect(networkProvider.request).toHaveBeenCalledWith({
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              gas: '0x5208',
+              from: '0x7309f0134f3e51e8cbe29dd86068e0f264f6c946',
+              to: mockedContract.address,
+              data: '0x18160ddd'
+            }
+          ]
+        })
+      })
+    })
+  })
+
+  describe("and the current chain id is not the same as the contract's chain id", () => {
+    describe('and the meta transaction fails to be sent', () => {
+      beforeEach(() => {
+        error = new Error('Meta transaction failed to be sent')
+        const networkProvider = buildMockedNetworkProvider()
+        const connectedNetworkProvider = buildMockedNetworkProvider({
+          ethChainId: Promise.resolve('0x89')
+        })
+
+        mockedGetNetworkProvider.mockResolvedValue(networkProvider as never)
+        mockedGetConnectedProvider.mockResolvedValue(
+          connectedNetworkProvider as never
+        )
+        mockedSendMetaTransaction.mockRejectedValueOnce(error as never)
+      })
+
+      it('should throw an error signaling the failure of the meta transaction', () => {
+        return expect(sendTransaction(contract, 'totalSupply')).rejects.toThrow(
+          error.message
+        )
+      })
+    })
+
+    describe('and the meta transaction is sent successfully', () => {
+      let networkProvider: MockedProvider
+      let connectedNetworkProvider: MockedProvider
+
+      beforeEach(() => {
+        networkProvider = buildMockedNetworkProvider()
+        connectedNetworkProvider = buildMockedNetworkProvider({
+          ethChainId: Promise.resolve('0x89')
+        })
+
+        mockedGetNetworkProvider.mockResolvedValue(networkProvider as never)
+        mockedGetConnectedProvider.mockResolvedValue(
+          connectedNetworkProvider as never
+        )
+        mockedSendMetaTransaction.mockResolvedValueOnce(
+          transactionHash as never
+        )
+      })
+
+      it('should resolve with the transaction hash', () => {
+        return expect(
+          sendTransaction(contract, 'totalSupply')
+        ).resolves.toEqual(transactionHash)
+      })
+
+      it('should have sent the meta transaction with all the required parameters', async () => {
+        await sendTransaction(contract, 'totalSupply')
+        expect(sendMetaTransaction).toHaveBeenCalledWith(
+          connectedNetworkProvider,
+          expect.any(providers.Web3Provider),
+          '0x18160ddd',
+          mockedContract,
+          {
+            serverURL: getTransactionsApiUrl()
+          }
+        )
+      })
+    })
+  })
+})

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -99,12 +99,28 @@ export type TransactionEventData<T extends TransactionEventType> = {
 
 export const transactionEvents = new EventEmitter()
 
+/**
+ * Sends a transaction either as a meta transaction or as a regular transaction.
+ * - If the contract chain id differs from the current provider chain id, a meta transaction will be sent.
+ * - If the contract chain id is the same as the current provider chain id, a regular transaction will be sent.
+ * @param contract - The contract to send the transaction to.
+ * @param contractMethodName - The name of the contract method to call.
+ * @param contractMethodArgs - The arguments to pass to the contract method.
+ */
 export async function sendTransaction(
   contract: ContractData,
   contractMethodName: string,
   ...contractArguments: any[]
 ): Promise<string>
 
+/**
+ * @deprecated
+ * Sends a transaction either as a meta transaction or as a regular transaction.
+ * - If the contract chain id differs from the current provider chain id, a meta transaction will be sent.
+ * - If the contract chain id is the same as the current provider chain id, a regular transaction will be sent.
+ * @param contract - The contract to send the transaction to.
+ * @param getPopulatedTransaction - A function that returns a populated transaction.
+ */
 export async function sendTransaction(
   contract: ContractData,
   getPopulatedTransaction: (

--- a/src/tests/transactions.ts
+++ b/src/tests/transactions.ts
@@ -1,0 +1,128 @@
+import { ChainId } from '@dcl/schemas'
+
+export const mockedContract = {
+  abi: [
+    {
+      constant: false,
+      inputs: [
+        {
+          name: '_from',
+          type: 'address'
+        },
+        {
+          name: '_to',
+          type: 'address'
+        },
+        {
+          name: '_value',
+          type: 'uint256'
+        }
+      ],
+      name: 'transferFrom',
+      outputs: [
+        {
+          name: '',
+          type: 'bool'
+        }
+      ],
+      payable: false,
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      constant: true,
+      inputs: [],
+      name: 'totalSupply',
+      outputs: [
+        {
+          name: '',
+          type: 'uint256'
+        }
+      ],
+      payable: false,
+      stateMutability: 'view',
+      type: 'function'
+    }
+  ],
+  address: '0x5a467398dfa9d5c663a656423a2d055f538198a4',
+  name: 'aContractName',
+  version: '1.0',
+  chainId: ChainId.MATIC_MUMBAI
+}
+
+type buildNetworkProviderOptions = {
+  ethChainId?: Promise<string>
+  ethAccounts?: Promise<string[]>
+  ethEstimateGas?: Promise<string>
+  ethSendTransaction?: Promise<string>
+  ethBlockNumber?: Promise<string>
+  eth_getTransactionByHash?: Promise<string>
+}
+
+export function buildMockedNetworkProvider(
+  options?: buildNetworkProviderOptions
+) {
+  const {
+    ethChainId,
+    ethAccounts,
+    ethEstimateGas,
+    ethSendTransaction,
+    ethBlockNumber,
+    eth_getTransactionByHash
+  } = options ?? {}
+
+  return {
+    request: jest
+      .fn()
+      .mockImplementation(
+        ({ method }: { method: string; params: string[] }) => {
+          switch (method) {
+            case 'eth_chainId':
+              return ethChainId ?? Promise.resolve('0x13881')
+            case 'eth_accounts':
+              return (
+                ethAccounts ??
+                Promise.resolve(['0x7309F0134f3e51E8CBE29dD86068e0F264F6c946'])
+              )
+            case 'eth_estimateGas':
+              return ethEstimateGas ?? Promise.resolve('0x5208')
+            case 'eth_sendTransaction':
+              return (
+                ethSendTransaction ??
+                Promise.resolve(
+                  '0xc9dd675b8949ce5d18b6cb4c9df888bb4c37ca02bbe54eb42d2b42514a0967c5'
+                )
+              )
+            case 'eth_blockNumber':
+              return ethBlockNumber ?? Promise.resolve('0x4b7')
+            case 'eth_getTransactionByHash':
+              return (
+                eth_getTransactionByHash ??
+                Promise.resolve({
+                  blockHash:
+                    '0x1d59ff54b1eb26b013ce3cb5fc9dab3705b415a67127a003c3e61eb445bb8df2',
+                  blockNumber: '0x4b7',
+                  from: '0x7309F0134f3e51E8CBE29dD86068e0F264F6c946',
+                  gas: '0x5208',
+                  gasPrice: '0x4a817c800',
+                  hash:
+                    '0xc9dd675b8949ce5d18b6cb4c9df888bb4c37ca02bbe54eb42d2b42514a0967c5',
+                  input: '0x68656c6c6f21',
+                  nonce: '0x15',
+                  to: mockedContract.address,
+                  transactionIndex: '0x41',
+                  value: '0xf3dbb76162000',
+                  v: '0x25',
+                  r:
+                    '0x1b5e176d927f8e9ab405058b2d2457392da3e20f328b16ddabcebc33eaac5fea',
+                  s:
+                    '0x4ba69724e8f69de52f0125ad8b3c5c2cef33019bac3249e2c0a2192766d1721c'
+                })
+              )
+            default:
+              throw new Error(`Unsupported method: ${method}`)
+          }
+        }
+      )
+  }
+}


### PR DESCRIPTION
This PR makes the `sendTransaction` function capable of receiving the name of the method to execute and its parameters so it doesn't have to receive an anonymous function, making the function testable.
This change is not a breaking change, the old behavior can be still used.