### PR TITLE
fix: toFixedMANAValue

### DIFF
--- a/src/lib/mana.spec.ts
+++ b/src/lib/mana.spec.ts
@@ -31,5 +31,16 @@ describe('when formatting the price', () => {
         expect(toFixedMANAValue('765.93023')).toBe('765.93')
       })
     })
+
+    describe('when the number has decimal zeros to the right', () => {
+      it('should remove them', () => {
+        expect(toFixedMANAValue('9.5000000')).toBe('9.5')
+      })
+    })
+    describe('when all the decimals are zeros', () => {
+      it('return an integer', () => {
+        expect(toFixedMANAValue('9.000')).toBe('9')
+      })
+    })
   })
 })

--- a/src/lib/mana.ts
+++ b/src/lib/mana.ts
@@ -18,6 +18,9 @@ export function toFixedMANAValue(
 
     if (decimalsCount >= maximumFractionDigits) {
       return value.toFixed(maximumFractionDigits)
+    } else if (Number(strValue) === value) {
+      // when the original string was a valid number, return the parsed value to remove trailing zeros
+      return value.toString()
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue with the `toFixedMANAValue` helper where trailing zeros would not be removed, allowing inputs to have more than the intended number of digits, ie:

- `9.500` nos is converted to `9.5`
- `9.000` now is converted to `9`