### PR TITLE
fix: format mana again

### DIFF
--- a/src/lib/mana.spec.ts
+++ b/src/lib/mana.spec.ts
@@ -1,4 +1,4 @@
-import { toFixedMANAValue } from './mana'
+import { getTrailingZeros, toFixedMANAValue } from './mana'
 
 describe('when formatting the price', () => {
   describe('when formatting alphanumeric text', () => {
@@ -10,6 +10,12 @@ describe('when formatting the price', () => {
   describe('when formatting an invalid number', () => {
     it('should return the supplied value', () => {
       expect(toFixedMANAValue('1.bc')).toBe('1.bc')
+    })
+  })
+
+  describe('when formatting an incomplete number', () => {
+    it('should return the supplied value', () => {
+      expect(toFixedMANAValue('1.')).toBe('1.')
     })
   })
 
@@ -33,13 +39,83 @@ describe('when formatting the price', () => {
     })
 
     describe('when the number has decimal zeros to the right', () => {
-      it('should remove them', () => {
-        expect(toFixedMANAValue('9.5000000')).toBe('9.5')
+      it('should remove them up to the maximum amount allowed', () => {
+        expect(toFixedMANAValue('9.5000000')).toBe('9.50')
       })
     })
+
     describe('when all the decimals are zeros', () => {
-      it('return an integer', () => {
-        expect(toFixedMANAValue('9.000')).toBe('9')
+      it('should remove them up to the maximum amount allowed', () => {
+        expect(toFixedMANAValue('9.000')).toBe('9.00')
+      })
+    })
+
+    describe('when it has the same amount of decimals as the maximum amount allowed', () => {
+      it('return the supplied value', () => {
+        expect(toFixedMANAValue('9.00')).toBe('9.00')
+      })
+    })
+
+    describe('when it has trailing zeros but they are less than the maximum amount of decimals allowed', () => {
+      it('return the supplied value', () => {
+        expect(toFixedMANAValue('9.0')).toBe('9.0')
+      })
+    })
+  })
+})
+
+describe('when getting trailing zeros', () => {
+  describe('and the input is incomplete', () => {
+    it('should return 0', () => {
+      expect(getTrailingZeros('1.')).toBe(0)
+    })
+  })
+  describe('and the input is invalid', () => {
+    it('should return 0', () => {
+      expect(getTrailingZeros('1.abc')).toBe(0)
+    })
+  })
+  describe('and the input is an integer', () => {
+    describe('and the input has no decimals', () => {
+      it('should return 0', () => {
+        expect(getTrailingZeros('1')).toBe(0)
+      })
+    })
+    describe('and the input has one decimal', () => {
+      it('should return 1', () => {
+        expect(getTrailingZeros('1.0')).toBe(1)
+      })
+    })
+    describe('and the input has two decimal', () => {
+      it('should return 1', () => {
+        expect(getTrailingZeros('1.00')).toBe(2)
+      })
+    })
+    describe('and the input has three decimal', () => {
+      it('should return 1', () => {
+        expect(getTrailingZeros('1.000')).toBe(3)
+      })
+    })
+  })
+  describe('and the input is a float', () => {
+    describe('and has no trailing zeros', () => {
+      it('should return 0', () => {
+        expect(getTrailingZeros('1.5')).toBe(0)
+      })
+    })
+    describe('and has one trailing zero', () => {
+      it('should return 1', () => {
+        expect(getTrailingZeros('1.50')).toBe(1)
+      })
+    })
+    describe('and has two trailing zeros', () => {
+      it('should return 2', () => {
+        expect(getTrailingZeros('1.500')).toBe(2)
+      })
+    })
+    describe('and has three trailing zeros', () => {
+      it('should return 3', () => {
+        expect(getTrailingZeros('1.5000')).toBe(3)
       })
     })
   })

--- a/src/lib/mana.ts
+++ b/src/lib/mana.ts
@@ -15,14 +15,38 @@ export function toFixedMANAValue(
   if (!isNaN(value)) {
     const decimals = value.toString().split('.')[1]
     const decimalsCount = decimals ? decimals.length : 0
-
-    if (decimalsCount >= maximumFractionDigits) {
+    const trailingZeros = getTrailingZeros(strValue)
+    if (trailingZeros + decimalsCount >= maximumFractionDigits) {
       return value.toFixed(maximumFractionDigits)
-    } else if (Number(strValue) === value) {
-      // when the original string was a valid number, return the parsed value to remove trailing zeros
-      return value.toString()
     }
   }
 
   return strValue
+}
+
+/**
+ * Returns the amount of trailing zeros
+ */
+export function getTrailingZeros(strValue: string) {
+  // count zeros
+  let zeros = 0
+  // parse string value to remove trailing zeros
+  const parsed = parseFloat(strValue)
+  // remove parsed value from original string value (ie. string value is "1.0576000" and parsed is "1.0576" the rest would be "000")
+  let rest = strValue.split(parsed.toString()).pop()
+  // if after removing the parsed value there's nothing left, return 0
+  if (!rest) {
+    return 0
+  }
+  // if the first char is a dot, skip it (this would be the case for an integer with decimals, like "1.00")
+  if (rest[0] === '.') {
+    rest = rest.slice(1)
+  }
+  // count zeros
+  while (rest[0] === '0') {
+    zeros++
+    rest = rest.slice(1)
+  }
+  // return amount
+  return zeros
 }


### PR DESCRIPTION
There were a few cases that I hadn't contemplated on my previous update 🤦 (#252). For instance, when formating an incomplete value, like `9.` that would be converted to `9`, and that would never allow a user to input a decimal value in an input that uses this helper on every update. 

For a max digits allowed of 2, with the previous update it worked like that:

- `9` -> `9` ✅ 
- `9.` -> `9` ❌ 
- `9.5` -> `9.5` ✅ 
- `9.50` -> `9.5` ❌ 
- `9.500` -> `9.5` ❌ 
- `9.5000` -> `9.5` ❌ 

Now it works like this: 

- `9` -> `9` ✅ 
- `9.` -> `9.` ✅ 
- `9.5` -> `9.5` ✅ 
- `9.50` -> `9.50` ✅ 
- `9.500` -> `9.50` ✅ 
- `9.5000` -> `9.50` ✅ 