### PR TITLE
feat: increment batch size

### DIFF
--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -53,7 +53,8 @@ export function createAuthorizationSaga() {
           )
           const ethersProvider = new ethersProviders.Web3Provider(provider)
           const multicallProvider = new providers.MulticallProvider(
-            ethersProvider
+            ethersProvider,
+            { batchSize: 500 } // defaults to 50
           )
           multicallProviders[chainId] = multicallProvider
         }


### PR DESCRIPTION
Using the issue data and testing it a bit more, 500 seems a good middleground. It reduces the calls like so:

FROM

<img width="554" alt="image" src="https://user-images.githubusercontent.com/692077/171277962-4a14fa8b-01d9-4582-86bc-55a77500b0f9.png">


TO

<img width="539" alt="image" src="https://user-images.githubusercontent.com/692077/171277817-ba83f583-f9a9-4a74-9005-4055e3ef71a7.png">


Closes #222