### PR TITLE
feat: move the logic from handleSwitchNetworkRequest sagas into utils

### DIFF
--- a/src/modules/wallet/sagas.spec.ts
+++ b/src/modules/wallet/sagas.spec.ts
@@ -10,7 +10,7 @@ import {
   switchNetworkSuccess
 } from './actions'
 import { getConnectedProvider, getNetworkProvider } from '../../lib/eth'
-import { getAddEthereumChainParameters, getProviderChainId } from './utils'
+import { switchProviderChainId } from './utils'
 
 const walletSaga = createWalletSaga({ CHAIN_ID: 1 })
 
@@ -47,10 +47,7 @@ describe('Wallet sagas', () => {
                 Promise.resolve(mockProvider)
               ],
               [
-                call([mockProvider, 'request'], {
-                  method: 'wallet_switchEthereumChain',
-                  params: [{ chainId: '0x1' }]
-                }),
+                call(switchProviderChainId, mockProvider, 1),
                 Promise.resolve(void 0)
               ]
             ])
@@ -72,61 +69,12 @@ describe('Wallet sagas', () => {
                 Promise.resolve(mockProvider)
               ],
               [
-                call([mockProvider, 'request'], {
-                  method: 'wallet_switchEthereumChain',
-                  params: [{ chainId: '0x1' }]
-                }),
+                call(switchProviderChainId, mockProvider, 1),
                 Promise.reject(switchError)
-              ],
-              [
-                call([mockProvider, 'request'], {
-                  method: 'wallet_addEthereumChain',
-                  params: [
-                    getAddEthereumChainParameters(ChainId.ETHEREUM_MAINNET)
-                  ]
-                }),
-                Promise.resolve()
-              ],
-              [call(getProviderChainId, mockProvider), Promise.resolve('0x1')]
-            ])
-            .put(switchNetworkSuccess(ChainId.ETHEREUM_MAINNET))
-            .dispatch(switchNetworkRequest(ChainId.ETHEREUM_MAINNET))
-            .run({ silenceTimeout: true })
-        })
-        it('should should fail if after using wallet_addEthereumChain the chainId did not change', () => {
-          const switchError = new Error('Could not switch') as Error & {
-            code: number
-          }
-          switchError.code = 4902
-          return expectSaga(walletSaga)
-            .provide([
-              [
-                matchers.call.fn(getConnectedProvider),
-                Promise.resolve(mockProvider)
-              ],
-              [
-                call([mockProvider, 'request'], {
-                  method: 'wallet_switchEthereumChain',
-                  params: [{ chainId: '0x1' }]
-                }),
-                Promise.reject(switchError)
-              ],
-              [
-                call([mockProvider, 'request'], {
-                  method: 'wallet_addEthereumChain',
-                  params: [
-                    getAddEthereumChainParameters(ChainId.ETHEREUM_MAINNET)
-                  ]
-                }),
-                Promise.resolve()
-              ],
-              [call(getProviderChainId, mockProvider), Promise.resolve('0x2')]
+              ]
             ])
             .put(
-              switchNetworkFailure(
-                ChainId.ETHEREUM_MAINNET,
-                'Error adding network: chainId did not change after adding network'
-              )
+              switchNetworkFailure(ChainId.ETHEREUM_MAINNET, 'Could not switch')
             )
             .dispatch(switchNetworkRequest(ChainId.ETHEREUM_MAINNET))
             .run({ silenceTimeout: true })

--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -190,14 +190,21 @@ function* handleConnectWalletSuccess() {
 function* handleSwitchNetworkRequest(action: SwitchNetworkRequestAction) {
   const { chainId } = action.payload
   const provider: Provider | null = yield call(getConnectedProvider)
-  try {
-    if (!provider) {
-      throw new Error('Could not get provider')
+
+  if (!provider) {
+    yield put(
+      switchNetworkFailure(
+        chainId,
+        'Error switching network: Could not get provider'
+      )
+    )
+  } else {
+    try {
+      yield call(switchProviderChainId, provider, chainId)
+      yield put(switchNetworkSuccess(chainId))
+    } catch (switchError) {
+      yield put(switchNetworkFailure(chainId, switchError.message))
     }
-    yield call(switchProviderChainId, provider, chainId)
-    yield put(switchNetworkSuccess(chainId))
-  } catch (switchError) {
-    yield put(switchNetworkFailure(chainId, switchError.message))
   }
 }
 

--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -53,10 +53,9 @@ import {
 } from './actions'
 import {
   buildWallet,
-  getAddEthereumChainParameters,
-  getProviderChainId,
   getTransactionsApiUrl,
-  setTransactionsApiUrl
+  setTransactionsApiUrl,
+  switchProviderChainId
 } from './utils'
 import { CreateWalletOptions, Wallet } from './types'
 import { getAppChainId, isConnected } from './selectors'
@@ -195,41 +194,10 @@ function* handleSwitchNetworkRequest(action: SwitchNetworkRequestAction) {
     if (!provider) {
       throw new Error('Could not get provider')
     }
-    yield call([provider, 'request'], {
-      method: 'wallet_switchEthereumChain',
-      params: [{ chainId: '0x' + chainId.toString(16) }]
-    })
+    yield call(switchProviderChainId, provider, chainId)
     yield put(switchNetworkSuccess(chainId))
   } catch (switchError) {
-    // This error code indicates that the chain has not been added to MetaMask.
-    if (provider && switchError.code === 4902) {
-      try {
-        yield call([provider, 'request'], {
-          method: 'wallet_addEthereumChain',
-          params: [getAddEthereumChainParameters(chainId)]
-        })
-        const newChainId: string = yield call(getProviderChainId, provider)
-        if (chainId !== parseInt(newChainId, 16)) {
-          throw new Error('chainId did not change after adding network')
-        }
-        yield put(switchNetworkSuccess(chainId))
-        return
-      } catch (addError) {
-        yield put(
-          switchNetworkFailure(
-            chainId,
-            `Error adding network: ${addError.message}`
-          )
-        )
-        return
-      }
-    }
-    yield put(
-      switchNetworkFailure(
-        chainId,
-        `Error switching network: ${switchError.message}`
-      )
-    )
+    yield put(switchNetworkFailure(chainId, switchError.message))
   }
 }
 

--- a/src/modules/wallet/utils.spec.ts
+++ b/src/modules/wallet/utils.spec.ts
@@ -8,7 +8,8 @@ import {
 import {
   getProviderChainId,
   getTransactionsApiUrl,
-  sendTransaction
+  sendTransaction,
+  switchProviderChainId
 } from './utils'
 
 jest.mock('../../lib/eth')
@@ -100,7 +101,7 @@ describe('when sending a transaction', () => {
   })
 
   describe("and the current chain id is the same as the contract's chain id", () => {
-    describe('and the transaction fails to be sent', () => {
+    describe('and the transaction  with know 4902 errors to be sent', () => {
       beforeEach(() => {
         error = new Error('Transaction failed to be sent')
         const networkProvider = {
@@ -341,6 +342,84 @@ describe('when getting the chain id from a provider', () => {
         ethChainId: Promise.resolve(80001)
       })
       expect(await getProviderChainId(provider as any)).toBe(80001)
+    })
+  })
+})
+
+describe('when switching the chain id from a provider', () => {
+  let provider: MockedProvider
+
+  describe('when wallet_switchEthereumChain succeeds', () => {
+    beforeEach(() => {
+      provider = buildMockedNetworkProvider({
+        walletSwitchEthereumChain: Promise.resolve(null)
+      })
+    })
+
+    it('should return the chainId in case that the request succeded', () => {
+      return expect(switchProviderChainId(provider as any, 1)).resolves.toBe(1)
+    })
+  })
+
+  describe('when wallet_switchEthereumChain fail with know 4902 error', () => {
+    let switchError: { message: string; code?: number }
+
+    beforeEach(() => {
+      switchError = { code: 4902, message: 'Could not switch' }
+
+      provider = buildMockedNetworkProvider({
+        walletSwitchEthereumChain: Promise.reject(switchError)
+      })
+    })
+
+    it('should try to use wallet_addEthereumChain instead', () => {
+      return expect(
+        switchProviderChainId(provider as any, 80001)
+      ).resolves.toBe(80001)
+    })
+
+    it('should try to use wallet_addEthereumChain and fails comparing chain requested with new chain', () => {
+      return expect(
+        switchProviderChainId(provider as any, 123)
+      ).rejects.toThrow(
+        'Error adding network: chainId did not change after adding network'
+      )
+    })
+  })
+
+  describe('when wallet_switchEthereumChain fail with know 4902 error and adding the new chain fails', () => {
+    let provider: MockedProvider
+    let switchError: { message: string; code?: number }
+    beforeEach(() => {
+      switchError = { code: 4902, message: 'Could not switch' }
+      const error = { message: 'add Ethereum chain' }
+      provider = buildMockedNetworkProvider({
+        walletSwitchEthereumChain: Promise.reject(switchError),
+        walletAddEthereumChain: Promise.reject(error)
+      })
+    })
+
+    it('should throw an Error adding network: add Ethereum chain', () => {
+      return expect(
+        switchProviderChainId(provider as any, 80001)
+      ).rejects.toThrow('Error adding network: add Ethereum chain')
+    })
+  })
+
+  describe('when wallet_switchEthereumChain fail', () => {
+    let provider: MockedProvider
+    const error = new Error('Could not switch')
+
+    beforeEach(() => {
+      provider = buildMockedNetworkProvider({
+        walletSwitchEthereumChain: Promise.reject(error)
+      })
+    })
+
+    it('should should return an error', () => {
+      return expect(switchProviderChainId(provider as any, 1)).rejects.toThrow(
+        'Error switching network: Could not switch'
+      )
     })
   })
 })

--- a/src/modules/wallet/utils.spec.ts
+++ b/src/modules/wallet/utils.spec.ts
@@ -387,7 +387,7 @@ describe('when switching the chain id from a provider', () => {
     })
   })
 
-  describe('when wallet_switchEthereumChain fail with know 4902 error and adding the new chain fails', () => {
+  describe('when wallet_switchEthereumChain fails with know 4902 error and adding the new chain fails', () => {
     let provider: MockedProvider
     let switchError: { message: string; code?: number }
     beforeEach(() => {

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -284,7 +284,7 @@ export async function switchProviderChainId(
     return chainId
   } catch (switchError) {
     // This error code indicates that the chain has not been added to MetaMask.
-    if (provider && switchError.code === 4902) {
+    if (provider && switchError?.code === 4902) {
       try {
         await provider.request({
           method: 'wallet_addEthereumChain',

--- a/src/modules/wallet/utils.ts
+++ b/src/modules/wallet/utils.ts
@@ -263,3 +263,43 @@ export async function getProviderChainId(provider: Provider): Promise<number> {
 
   return chainId
 }
+
+/**
+ * Change the provider's chain to a provided chain.
+ * In case it returns an error that the chain does not exist, it will try to add it.
+ * @param provider - The provider used to swith the chain
+ * @param chainId - The chain id that is being changed
+ * @returns A number representing the chain id
+ */
+export async function switchProviderChainId(
+  provider: Provider,
+  chainId: ChainId
+) {
+  try {
+    await provider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: '0x' + chainId.toString(16) }]
+    })
+
+    return chainId
+  } catch (switchError) {
+    // This error code indicates that the chain has not been added to MetaMask.
+    if (provider && switchError.code === 4902) {
+      try {
+        await provider.request({
+          method: 'wallet_addEthereumChain',
+          params: [getAddEthereumChainParameters(chainId)]
+        })
+        const newChainId = await getProviderChainId(provider)
+
+        if (chainId !== newChainId) {
+          throw new Error('chainId did not change after adding network')
+        }
+        return chainId
+      } catch (addError) {
+        throw new Error(`Error adding network: ${addError.message}`)
+      }
+    }
+    throw new Error(`Error switching network: ${switchError.message}`)
+  }
+}

--- a/src/tests/transactions.ts
+++ b/src/tests/transactions.ts
@@ -52,6 +52,8 @@ type buildNetworkProviderOptions = {
   ethSendTransaction?: Promise<string>
   ethBlockNumber?: Promise<string>
   eth_getTransactionByHash?: Promise<string>
+  walletSwitchEthereumChain?: Promise<null>
+  walletAddEthereumChain?: Promise<null>
 }
 
 export function buildMockedNetworkProvider(
@@ -63,7 +65,9 @@ export function buildMockedNetworkProvider(
     ethEstimateGas,
     ethSendTransaction,
     ethBlockNumber,
-    eth_getTransactionByHash
+    eth_getTransactionByHash,
+    walletSwitchEthereumChain,
+    walletAddEthereumChain
   } = options ?? {}
 
   return {
@@ -114,6 +118,10 @@ export function buildMockedNetworkProvider(
                     '0x4ba69724e8f69de52f0125ad8b3c5c2cef33019bac3249e2c0a2192766d1721c'
                 })
               )
+            case 'wallet_switchEthereumChain':
+              return walletSwitchEthereumChain ?? Promise.resolve(null)
+            case 'wallet_addEthereumChain':
+              return walletAddEthereumChain ?? Promise.resolve(null)
             default:
               throw new Error(`Unsupported method: ${method}`)
           }


### PR DESCRIPTION
We moved part of the chain switch logic used in the handleSwitchNetworkRequest sagas, so that we can use this utility within other projects such as explorer-website.