### PR TITLE
feat: Get segment anonymous user id

### DIFF
--- a/src/modules/analytics/snippet.ts
+++ b/src/modules/analytics/snippet.ts
@@ -28,6 +28,7 @@
     'ready',
     'alias',
     'debug',
+    'user',
     'page',
     'once',
     'off',

--- a/src/modules/analytics/utils.ts
+++ b/src/modules/analytics/utils.ts
@@ -86,3 +86,12 @@ export function trackConnectWallet(
     analytics.track('Connect Wallet', props)
   }
 }
+
+export function getAnonymousId() {
+  const analytics = getAnalytics()
+  if (analytics) {
+    return analytics.user().anonymousId()
+  } else {
+    return undefined
+  }
+}


### PR DESCRIPTION
This PR adds `user` to analytics methods to the stub, allowing to get the user `anonymousId` when the segment analytics lib is ready.