### PR TITLE
feat: Add feature flags loading selectors

### DIFF
--- a/src/modules/features/reducer.spec.ts
+++ b/src/modules/features/reducer.spec.ts
@@ -15,7 +15,7 @@ describe('when handling the fetch features request', () => {
     ])
 
     const state = featuresReducer(
-      { data: {}, loading: [], error: 'error' },
+      { data: {}, hasLoadedInitialFlags: false, loading: [], error: 'error' },
       action
     )
 
@@ -24,14 +24,19 @@ describe('when handling the fetch features request', () => {
 })
 
 describe('when handling the fetch features success', () => {
-  it('should update data and remove the request action from the loading state', () => {
+  it("should update data, remove the request action from the loading state and set the flag to signal that the ff's were loaded", () => {
     const apps = [ApplicationName.ACCOUNT, ApplicationName.BUILDER]
     const requestAction = fetchApplicationFeaturesRequest(apps)
     const features = getMockApplicationFeaturesRecord()
     const successAction = fetchApplicationFeaturesSuccess(apps, features)
 
     const state = featuresReducer(
-      { data: {}, loading: [requestAction], error: null },
+      {
+        data: {},
+        hasLoadedInitialFlags: true,
+        loading: [requestAction],
+        error: null
+      },
       successAction
     )
 
@@ -47,7 +52,12 @@ describe('when handling the fetch features failure', () => {
     const failureAction = fetchApplicationFeaturesFailure(apps, error)
 
     const state = featuresReducer(
-      { data: {}, loading: [requestAction], error: null },
+      {
+        data: {},
+        hasLoadedInitialFlags: false,
+        loading: [requestAction],
+        error: null
+      },
       failureAction
     )
 

--- a/src/modules/features/reducer.spec.ts
+++ b/src/modules/features/reducer.spec.ts
@@ -19,7 +19,12 @@ describe('when handling the fetch features request', () => {
       action
     )
 
-    expect(state).toEqual({ data: {}, loading: [action], error: null })
+    expect(state).toEqual({
+      data: {},
+      loading: [action],
+      hasLoadedInitialFlags: false,
+      error: null
+    })
   })
 })
 
@@ -40,7 +45,12 @@ describe('when handling the fetch features success', () => {
       successAction
     )
 
-    expect(state).toEqual({ data: features, loading: [], error: null })
+    expect(state).toEqual({
+      data: features,
+      loading: [],
+      hasLoadedInitialFlags: true,
+      error: null
+    })
   })
 })
 
@@ -61,6 +71,11 @@ describe('when handling the fetch features failure', () => {
       failureAction
     )
 
-    expect(state).toEqual({ data: {}, loading: [], error })
+    expect(state).toEqual({
+      data: {},
+      loading: [],
+      hasLoadedInitialFlags: false,
+      error
+    })
   })
 })

--- a/src/modules/features/reducer.ts
+++ b/src/modules/features/reducer.ts
@@ -12,12 +12,14 @@ import { ApplicationFeatures } from './types'
 export type FeaturesState = {
   data: Record<string, ApplicationFeatures>
   loading: LoadingState
+  hasLoadedInitialFlags: boolean
   error: string | null
 }
 
 export const INITIAL_STATE: FeaturesState = {
   data: {},
   loading: [],
+  hasLoadedInitialFlags: false,
   error: null
 }
 
@@ -44,6 +46,7 @@ export const featuresReducer = (
       return {
         ...state,
         loading: loadingReducer(state.loading, action),
+        hasLoadedInitialFlags: true,
         data: features
       }
     }

--- a/src/modules/features/selectors.spec.ts
+++ b/src/modules/features/selectors.spec.ts
@@ -180,70 +180,76 @@ describe('when getting if a feature is enabled', () => {
 })
 
 describe('when getting if the feature flags were loaded at least once', () => {
+  let state: StateWithFeatures
+
+  beforeEach(() => {
+    state = {
+      features: {
+        data: {},
+        error: null,
+        hasLoadedInitialFlags: false,
+        loading: []
+      }
+    }
+  })
+
   describe('and the feature flags were not loaded', () => {
-    it('should return true', () => {
-      expect(
-        hasLoadedInitialFlags({
-          features: {
-            data: {},
-            error: null,
-            hasLoadedInitialFlags: false,
-            loading: []
-          }
-        })
-      ).toBe(true)
+    beforeEach(() => {
+      state.features.hasLoadedInitialFlags = false
+    })
+
+    it('should return false', () => {
+      expect(hasLoadedInitialFlags(state)).toBe(false)
     })
   })
 
   describe('and the feature flags were loaded', () => {
-    it('should return false', () => {
-      expect(
-        hasLoadedInitialFlags({
-          features: {
-            data: {},
-            error: null,
-            hasLoadedInitialFlags: false,
-            loading: []
-          }
-        })
-      ).toBe(false)
+    beforeEach(() => {
+      state.features.hasLoadedInitialFlags = true
+    })
+
+    it('should return true', () => {
+      expect(hasLoadedInitialFlags(state)).toBe(true)
     })
   })
 })
 
 describe('when getting is the feature flags are being loaded', () => {
+  let state: StateWithFeatures
+
+  beforeEach(() => {
+    state = {
+      features: {
+        data: {},
+        error: null,
+        hasLoadedInitialFlags: false,
+        loading: []
+      }
+    }
+  })
+
   describe('and the feature flags are being loaded', () => {
+    beforeEach(() => {
+      state.features.loading = [
+        fetchApplicationFeaturesRequest([
+          ApplicationName.ACCOUNT,
+          ApplicationName.BUILDER
+        ])
+      ]
+    })
+
     it('should return true', () => {
-      expect(
-        isLoadingFeatureFlags({
-          features: {
-            data: {},
-            error: null,
-            hasLoadedInitialFlags: false,
-            loading: [
-              fetchApplicationFeaturesRequest([
-                ApplicationName.ACCOUNT,
-                ApplicationName.BUILDER
-              ])
-            ]
-          }
-        })
-      ).toBe(true)
+      expect(isLoadingFeatureFlags(state)).toBe(true)
     })
   })
 
   describe('and the feature flags are not being loaded', () => {
+    beforeEach(() => {
+      state.features.loading = []
+    })
+
     it('should return false', () => {
-      expect(
-        isLoadingFeatureFlags({
-          features: {
-            data: {},
-            error: null,
-            hasLoadedInitialFlags: false,
-            loading: []
-          }
-        })
-      ).toBe(false)
+      expect(isLoadingFeatureFlags(state)).toBe(false)
     })
   })
 })

--- a/src/modules/features/selectors.spec.ts
+++ b/src/modules/features/selectors.spec.ts
@@ -1,6 +1,13 @@
 import { fetchApplicationFeaturesRequest } from './actions'
 import { getMockApplicationFeaturesRecord } from './actions.spec'
-import { getData, getError, getIsFeatureEnabled, getLoading } from './selectors'
+import {
+  getData,
+  getError,
+  getIsFeatureEnabled,
+  getLoading,
+  hasLoadedInitialFlags,
+  isLoadingFeatureFlags
+} from './selectors'
 import { ApplicationName, StateWithFeatures } from './types'
 
 describe('when getting the features state data', () => {
@@ -11,6 +18,7 @@ describe('when getting the features state data', () => {
       features: {
         data,
         error: null,
+        hasLoadedInitialFlags: false,
         loading: []
       }
     })
@@ -32,6 +40,7 @@ describe('when getting the features state loading', () => {
       features: {
         data: {},
         error: null,
+        hasLoadedInitialFlags: false,
         loading
       }
     })
@@ -48,6 +57,7 @@ describe('when getting the features state error', () => {
       features: {
         data: {},
         error,
+        hasLoadedInitialFlags: false,
         loading: []
       }
     })
@@ -65,6 +75,7 @@ describe('when getting if a feature is enabled', () => {
         features: {
           data,
           error: null,
+          hasLoadedInitialFlags: false,
           loading: []
         }
       }
@@ -83,6 +94,7 @@ describe('when getting if a feature is enabled', () => {
         features: {
           data,
           error: null,
+          hasLoadedInitialFlags: false,
           loading: []
         }
       }
@@ -101,6 +113,7 @@ describe('when getting if a feature is enabled', () => {
         features: {
           data: {},
           error: null,
+          hasLoadedInitialFlags: false,
           loading: []
         }
       }
@@ -124,6 +137,7 @@ describe('when getting if a feature is enabled', () => {
         features: {
           data: {},
           loading: [],
+          hasLoadedInitialFlags: false,
           error: null
         }
       }
@@ -161,6 +175,75 @@ describe('when getting if a feature is enabled', () => {
 
         expect(result).toEqual(false)
       })
+    })
+  })
+})
+
+describe('when getting if the feature flags were loaded at least once', () => {
+  describe('and the feature flags were not loaded', () => {
+    it('should return true', () => {
+      expect(
+        hasLoadedInitialFlags({
+          features: {
+            data: {},
+            error: null,
+            hasLoadedInitialFlags: false,
+            loading: []
+          }
+        })
+      ).toBe(true)
+    })
+  })
+
+  describe('and the feature flags were loaded', () => {
+    it('should return false', () => {
+      expect(
+        hasLoadedInitialFlags({
+          features: {
+            data: {},
+            error: null,
+            hasLoadedInitialFlags: false,
+            loading: []
+          }
+        })
+      ).toBe(false)
+    })
+  })
+})
+
+describe('when getting is the feature flags are being loaded', () => {
+  describe('and the feature flags are being loaded', () => {
+    it('should return true', () => {
+      expect(
+        isLoadingFeatureFlags({
+          features: {
+            data: {},
+            error: null,
+            hasLoadedInitialFlags: false,
+            loading: [
+              fetchApplicationFeaturesRequest([
+                ApplicationName.ACCOUNT,
+                ApplicationName.BUILDER
+              ])
+            ]
+          }
+        })
+      ).toBe(true)
+    })
+  })
+
+  describe('and the feature flags are not being loaded', () => {
+    it('should return false', () => {
+      expect(
+        isLoadingFeatureFlags({
+          features: {
+            data: {},
+            error: null,
+            hasLoadedInitialFlags: false,
+            loading: []
+          }
+        })
+      ).toBe(false)
     })
   })
 })

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -1,4 +1,3 @@
-import { AnyAction } from 'redux'
 import { LoadingState } from '../loading/reducer'
 import { isLoadingType } from '../loading/selectors'
 import { FETCH_APPLICATION_FEATURES_REQUEST } from './actions'

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -1,4 +1,7 @@
+import { AnyAction } from 'redux'
 import { LoadingState } from '../loading/reducer'
+import { isLoadingType } from '../loading/selectors'
+import { FETCH_APPLICATION_FEATURES_REQUEST } from './actions'
 import { FeaturesState } from './reducer'
 import {
   ApplicationName,
@@ -53,6 +56,14 @@ export const getIsFeatureEnabled = (
   }
 
   return !!appFeatures.flags[`${app}-${feature}`]
+}
+
+export const isLoadingFeatureFlags = (state: StateWithFeatures) => {
+  return isLoadingType(getLoading(state), FETCH_APPLICATION_FEATURES_REQUEST)
+}
+
+export const hasLoadedInitialFlags = (state: StateWithFeatures) => {
+  return state.features.hasLoadedInitialFlags
 }
 
 const getFromEnv = (


### PR DESCRIPTION
This PR adds two selectors to the feature flags module:
1. `isLoadingFeatureFlags` that retrieves if the feature flags are being loaded to avoid using the `getLoading` selector
2. `hasLoadedInitialFlags` that retrieves if the feature flags were loaded at least once.