### PR TITLE
chore: setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     allow:
       - dependency-name: '@dcl/*'
       - dependency-name: 'decentraland-*'
+      - dependency-name: 'dcl-*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Keep Decentraland packages up to date
+
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    allow:
+      - dependency-name: '@dcl/*'
+      - dependency-name: 'decentraland-*'


### PR DESCRIPTION
This PR setup dependabot to check weekly for decentraland dependencies.

Hopefully this will mitigate the dependencies duplication on dependent projects

<img width="268" alt="Screenshot 2023-01-25 at 11 32 52" src="https://user-images.githubusercontent.com/208789/214590609-c763c25c-1840-4cb1-82ca-a693e0f53cce.png">

Issues:

- decentraland/unity-renderer#4027
