### PR TITLE
feat: Make partially supported network modal optional

### DIFF
--- a/src/containers/Navbar/Navbar.tsx
+++ b/src/containers/Navbar/Navbar.tsx
@@ -47,7 +47,8 @@ export default class Navbar extends React.PureComponent<NavbarProps> {
     const {
       appChainId,
       hasAcceptedNetworkPartialSupport,
-      onAcceptNetworkPartialSupport
+      onAcceptNetworkPartialSupport,
+      showPartiallySupportedModal = true
     } = this.props
     const expectedChainName = getChainName(appChainId)
     return (
@@ -89,7 +90,7 @@ export default class Navbar extends React.PureComponent<NavbarProps> {
                   </Button>
                 </Modal.Actions>
               </Modal>
-            ) : isPartiallySupported ? (
+            ) : isPartiallySupported && showPartiallySupportedModal ? (
               <Modal open={!hasAcceptedNetworkPartialSupport} size="small">
                 <ModalNavigation
                   title={

--- a/src/containers/Navbar/Navbar.types.tsx
+++ b/src/containers/Navbar/Navbar.types.tsx
@@ -16,7 +16,7 @@ export type NavbarProps = NavbarComponentProps & {
   onSwitchNetwork: typeof switchNetworkRequest
   onSignOut: typeof disconnectWallet
   hasAcceptedNetworkPartialSupport: boolean
-  showPartiallySupportedModal: boolean
+  showPartiallySupportedModal?: boolean
   onAcceptNetworkPartialSupport: typeof acceptNetworkPartialSupport
 }
 

--- a/src/containers/Navbar/Navbar.types.tsx
+++ b/src/containers/Navbar/Navbar.types.tsx
@@ -16,6 +16,7 @@ export type NavbarProps = NavbarComponentProps & {
   onSwitchNetwork: typeof switchNetworkRequest
   onSignOut: typeof disconnectWallet
   hasAcceptedNetworkPartialSupport: boolean
+  showPartiallySupportedModal: boolean
   onAcceptNetworkPartialSupport: typeof acceptNetworkPartialSupport
 }
 


### PR DESCRIPTION
This PR makes the "partially supported network modal" optional so we can choose to not show it if we need to change the user experience.