### PR TITLE
feat: DAPPS Application Name

### DIFF
--- a/src/modules/features/selectors.spec.ts
+++ b/src/modules/features/selectors.spec.ts
@@ -38,9 +38,9 @@ describe('when getting the features state data', () => {
       state = {}
     })
 
-    it('should throw an error indicating features module was not implemented', () => {
+    it('should throw an error indicating features reducer was not implemented', () => {
       expect(() => getData(state)).toThrowError(
-        "'features' module not implemented"
+        "'features' reducer not implemented"
       )
     })
   })
@@ -152,7 +152,7 @@ describe('when getting if a feature is enabled', () => {
         ).toEqual(true)
       })
 
-      describe('and the feature module is undefined', () => {
+      describe('and the feature reducer is undefined', () => {
         beforeEach(() => {
           state = {}
         })

--- a/src/modules/features/selectors.spec.ts
+++ b/src/modules/features/selectors.spec.ts
@@ -11,8 +11,8 @@ import {
 import { ApplicationName, StateWithFeatures } from './types'
 
 describe('when getting the features state data', () => {
-  let state: StateWithFeatures
   let data: ReturnType<typeof getMockApplicationFeaturesRecord>
+  let state: StateWithFeatures
 
   describe('when features is defined', () => {
     beforeEach(() => {
@@ -86,19 +86,24 @@ describe('when getting the features state error', () => {
 })
 
 describe('when getting if a feature is enabled', () => {
+  let data: ReturnType<typeof getMockApplicationFeaturesRecord>
+  let state: StateWithFeatures
+
+  beforeEach(() => {
+    data = getMockApplicationFeaturesRecord()
+
+    state = {
+      features: {
+        data,
+        error: null,
+        hasLoadedInitialFlags: false,
+        loading: []
+      }
+    }
+  })
+
   describe('when the application feature is stored as true', () => {
     it('should return true', () => {
-      const data = getMockApplicationFeaturesRecord()
-
-      const state = {
-        features: {
-          data,
-          error: null,
-          hasLoadedInitialFlags: false,
-          loading: []
-        }
-      }
-
       expect(
         getIsFeatureEnabled(state, ApplicationName.ACCOUNT, 'flag1')
       ).toEqual(true)
@@ -107,17 +112,6 @@ describe('when getting if a feature is enabled', () => {
 
   describe('when the application feature is stored as false', () => {
     it('should return false', () => {
-      const data = getMockApplicationFeaturesRecord()
-
-      const state = {
-        features: {
-          data,
-          error: null,
-          hasLoadedInitialFlags: false,
-          loading: []
-        }
-      }
-
       expect(
         getIsFeatureEnabled(state, ApplicationName.ACCOUNT, 'flag2')
       ).toEqual(false)
@@ -125,41 +119,20 @@ describe('when getting if a feature is enabled', () => {
   })
 
   describe('when the application is not found in the state', () => {
-    it('should throw an application not found error', () => {
-      const featureName = 'feature-name'
-
-      const state = {
-        features: {
-          data: {},
-          error: null,
-          hasLoadedInitialFlags: false,
-          loading: []
-        }
-      }
-
-      expect(() =>
-        getIsFeatureEnabled(state, ApplicationName.ACCOUNT, featureName)
-      ).toThrow('Application "account" not found')
+    it('should return false', () => {
+      expect(
+        getIsFeatureEnabled(state, ApplicationName.DAPPS, 'flag1')
+      ).toEqual(false)
     })
   })
 
   describe('when the feature is found in the env', () => {
     const env = process.env
 
-    let state: StateWithFeatures
     let featureName: string
 
     beforeEach(() => {
       process.env = { ...env }
-
-      state = {
-        features: {
-          data: {},
-          loading: [],
-          hasLoadedInitialFlags: false,
-          error: null
-        }
-      }
 
       featureName = 'crazy-feature-name'
     })
@@ -169,30 +142,50 @@ describe('when getting if a feature is enabled', () => {
     })
 
     describe('when the env is 1', () => {
-      it('should return true from the env', () => {
+      beforeEach(() => {
         process.env.REACT_APP_FF_ACCOUNT_CRAZY_FEATURE_NAME = '1'
+      })
 
-        const result = getIsFeatureEnabled(
-          state,
-          ApplicationName.ACCOUNT,
-          featureName
-        )
+      it('should return true', () => {
+        expect(
+          getIsFeatureEnabled(state, ApplicationName.ACCOUNT, featureName)
+        ).toEqual(true)
+      })
 
-        expect(result).toEqual(true)
+      describe('and the feature module is undefined', () => {
+        beforeEach(() => {
+          state = {}
+        })
+
+        it('should return true', () => {
+          expect(
+            getIsFeatureEnabled(state, ApplicationName.ACCOUNT, featureName)
+          ).toEqual(true)
+        })
       })
     })
 
     describe('when the env is 0', () => {
-      it('should return false from the env', () => {
+      beforeEach(() => {
         process.env.REACT_APP_FF_ACCOUNT_CRAZY_FEATURE_NAME = '0'
+      })
 
-        const result = getIsFeatureEnabled(
-          state,
-          ApplicationName.ACCOUNT,
-          featureName
-        )
+      it('should return false', () => {
+        expect(
+          getIsFeatureEnabled(state, ApplicationName.ACCOUNT, featureName)
+        ).toEqual(false)
+      })
+    })
 
-        expect(result).toEqual(false)
+    describe('when the env is neither 0 or 1', () => {
+      beforeEach(() => {
+        process.env.REACT_APP_FF_ACCOUNT_CRAZY_FEATURE_NAME = 'pikachu'
+      })
+
+      it('should return false', () => {
+        expect(
+          getIsFeatureEnabled(state, ApplicationName.ACCOUNT, featureName)
+        ).toEqual(false)
       })
     })
   })

--- a/src/modules/features/selectors.spec.ts
+++ b/src/modules/features/selectors.spec.ts
@@ -11,19 +11,38 @@ import {
 import { ApplicationName, StateWithFeatures } from './types'
 
 describe('when getting the features state data', () => {
-  it('should return the features data', () => {
-    const data = getMockApplicationFeaturesRecord()
+  let state: StateWithFeatures
+  let data: ReturnType<typeof getMockApplicationFeaturesRecord>
 
-    const result = getData({
-      features: {
-        data,
-        error: null,
-        hasLoadedInitialFlags: false,
-        loading: []
+  describe('when features is defined', () => {
+    beforeEach(() => {
+      data = getMockApplicationFeaturesRecord()
+
+      state = {
+        features: {
+          data,
+          error: null,
+          hasLoadedInitialFlags: false,
+          loading: []
+        }
       }
     })
 
-    expect(result).toEqual(data)
+    it('should return the features data', () => {
+      expect(getData(state)).toEqual(data)
+    })
+  })
+
+  describe('when features is undefined', () => {
+    beforeEach(() => {
+      state = {}
+    })
+
+    it('should throw an error indicating features module was not implemented', () => {
+      expect(() => getData(state)).toThrowError(
+        "'features' module not implemented"
+      )
+    })
   })
 })
 
@@ -195,7 +214,7 @@ describe('when getting if the feature flags were loaded at least once', () => {
 
   describe('and the feature flags were not loaded', () => {
     beforeEach(() => {
-      state.features.hasLoadedInitialFlags = false
+      state.features!.hasLoadedInitialFlags = false
     })
 
     it('should return false', () => {
@@ -205,7 +224,7 @@ describe('when getting if the feature flags were loaded at least once', () => {
 
   describe('and the feature flags were loaded', () => {
     beforeEach(() => {
-      state.features.hasLoadedInitialFlags = true
+      state.features!.hasLoadedInitialFlags = true
     })
 
     it('should return true', () => {
@@ -230,7 +249,7 @@ describe('when getting is the feature flags are being loaded', () => {
 
   describe('and the feature flags are being loaded', () => {
     beforeEach(() => {
-      state.features.loading = [
+      state.features!.loading = [
         fetchApplicationFeaturesRequest([
           ApplicationName.ACCOUNT,
           ApplicationName.BUILDER
@@ -245,7 +264,7 @@ describe('when getting is the feature flags are being loaded', () => {
 
   describe('and the feature flags are not being loaded', () => {
     beforeEach(() => {
-      state.features.loading = []
+      state.features!.loading = []
     })
 
     it('should return false', () => {

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -66,7 +66,7 @@ export const getIsFeatureEnabled = (
     return false
   }
 
-  return !!appFlags.flags[`${app}-${feature}`] ?? false
+  return !!appFlags.flags[`${app}-${feature}`]
 }
 
 export const isLoadingFeatureFlags = (state: StateWithFeatures) => {

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -11,10 +11,10 @@ import {
 export const getState = (state: StateWithFeatures): FeaturesState => {
   const { features } = state
 
-  // If the features prop is undefined in the state, it is because the client has not implemented the features module.
-  // If any feature inside this lib requires querying the features module, it should try-catch any query to the state and handle accordingly. (Ignore checking for feature flags, etc.)
+  // If the features prop is undefined in the state, it is because the client has not implemented the features reducer.
+  // If any feature inside this lib requires querying the features reducer, it should try-catch any query to the state and handle accordingly. (Ignore checking for feature flags, etc.)
   if (!features) {
-    throw new Error("'features' module not implemented")
+    throw new Error("'features' reducer not implemented")
   }
 
   return features

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -8,8 +8,15 @@ import {
   StateWithFeatures
 } from './types'
 
-export const getState = (state: StateWithFeatures): FeaturesState =>
-  state.features!
+export const getState = (state: StateWithFeatures): FeaturesState => {
+  const { features } = state
+
+  if (!features) {
+    throw new Error("'features' module not implemented")
+  }
+
+  return features
+}
 
 export const getData = (
   state: StateWithFeatures

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -11,6 +11,8 @@ import {
 export const getState = (state: StateWithFeatures): FeaturesState => {
   const { features } = state
 
+  // If the features prop is undefined in the state, it is because the client has not implemented the features module.
+  // If any feature inside this lib requires querying the features module, it should try-catch any query to the state and handle accordingly. (Ignore checking for feature flags, etc.)
   if (!features) {
     throw new Error("'features' module not implemented")
   }

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -69,7 +69,7 @@ export const isLoadingFeatureFlags = (state: StateWithFeatures) => {
 }
 
 export const hasLoadedInitialFlags = (state: StateWithFeatures) => {
-  return state.features.hasLoadedInitialFlags
+  return getState(state).hasLoadedInitialFlags
 }
 
 const getFromEnv = (

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -50,20 +50,23 @@ export const getIsFeatureEnabled = (
   app: ApplicationName,
   feature: string
 ): boolean => {
-  const envValue = getFromEnv(app, feature)
+  const env = getFromEnv(app, feature)
 
-  if (envValue !== null) {
-    return envValue
+  // Return the flag value if it has been defined in the env.
+  // If flags are only defined in the env, there is no need to implement the features reducer.
+  if (env !== null) {
+    return env
   }
 
-  const features = getData(state)
-  const appFeatures: ApplicationFeatures | undefined = features[app]
+  const appFlags = getData(state)[app]
 
-  if (!appFeatures) {
-    throw new Error(`Application "${app}" not found`)
+  // The app might not be defined in the store because the flags might not have been fetched yet.
+  // We suggest using isLoadingFeatureFlags and hasLoadedInitialFlags to handle this first.
+  if (!appFlags) {
+    return false
   }
 
-  return !!appFeatures.flags[`${app}-${feature}`]
+  return !!appFlags.flags[`${app}-${feature}`] ?? false
 }
 
 export const isLoadingFeatureFlags = (state: StateWithFeatures) => {

--- a/src/modules/features/types.ts
+++ b/src/modules/features/types.ts
@@ -25,6 +25,7 @@ export enum ApplicationName {
   DAO = 'dao',
   EVENTS = 'events',
   LANDING = 'landing',
+  DAPPS = 'dapps',
   TEST = 'test'
 }
 

--- a/src/modules/features/types.ts
+++ b/src/modules/features/types.ts
@@ -39,7 +39,7 @@ export type FeatureSagasConfig = {
 }
 
 export type StateWithFeatures = {
-  // Possibly undefined because clients might not have implemented te features module into their dapps.
+  // Possibly undefined because clients might not have implemented the features module into their dapps.
   // This allows us to check that before operating on it.
   features?: FeaturesState
 }

--- a/src/modules/features/types.ts
+++ b/src/modules/features/types.ts
@@ -39,5 +39,7 @@ export type FeatureSagasConfig = {
 }
 
 export type StateWithFeatures = {
-  features: FeaturesState
+  // Possibly undefined because clients might not have implemented te features module into their dapps.
+  // This allows us to check that before operating on it.
+  features?: FeaturesState
 }

--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -91,7 +91,7 @@ export function* walletSaga() {
     takeEvery(DISCONNECT_WALLET, handleDisconnectWallet),
     takeEvery(CONNECT_WALLET_SUCCESS, handleConnectWalletSuccess),
     takeEvery(SWITCH_NETWORK_REQUEST, handleSwitchNetworkRequest),
-    takeEvery(SWITCH_NETWORK_SUCCESS, handleSwitchNetworkSucces)
+    takeEvery(SWITCH_NETWORK_SUCCESS, handleSwitchNetworkSuccess)
   ])
 }
 
@@ -208,7 +208,7 @@ function* handleSwitchNetworkRequest(action: SwitchNetworkRequestAction) {
   }
 }
 
-function* handleSwitchNetworkSucces(_action: SwitchNetworkSuccessAction) {
+function* handleSwitchNetworkSuccess(_action: SwitchNetworkSuccessAction) {
   yield put(fetchWalletRequest())
 }
 

--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -51,12 +51,9 @@ import {
   SwitchNetworkSuccessAction,
   setAppChainId
 } from './actions'
-import {
-  getTransactionsApiUrl,
-  setTransactionsApiUrl
-} from './utils'
-import { switchProviderChainId } from "./utils/switchProviderChainId"
-import { buildWallet } from "./utils/buildWallet"
+import { getTransactionsApiUrl, setTransactionsApiUrl } from './utils'
+import { switchProviderChainId } from './utils/switchProviderChainId'
+import { buildWallet } from './utils/buildWallet'
 import { CreateWalletOptions, Wallet } from './types'
 import { getAppChainId, isConnected } from './selectors'
 

--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -133,6 +133,7 @@ function* handleEnableWalletRequest(action: EnableWalletRequestAction) {
         providerType,
         _getAppChainId()
       )
+
       return account
     })
 


### PR DESCRIPTION
Changes:
- Add DAPPS app name to enum
- `StateWithFeatures` type has a possibly undefined features property. Clients might not be implementing the reducer so it might be possible that it is undefined. By typing it accordingly, we might be able to handle it right.
- `getState` now throws a `"'features' module not implemented"` error.
- `getIsFeatureEnabled` returns false if the provided app cannot be found in the state. There might be cases where the features are still loading and the app hasn't been added.