### PR TITLE
fix: Dropped watched transaction error

### DIFF
--- a/src/lib/eth.ts
+++ b/src/lib/eth.ts
@@ -54,6 +54,11 @@ export async function getNetworkProvider(chainId: ChainId): Promise<Provider> {
   return connection.createProvider(ProviderType.NETWORK, chainId)
 }
 
+export async function getNetworkWeb3Provider(chainId: ChainId) {
+  const provider = await getNetworkProvider(chainId)
+  return new ethers.providers.Web3Provider(provider)
+}
+
 export async function getConnectedProvider(): Promise<Provider | null> {
   try {
     const { provider } = await connection.tryPreviousConnection()

--- a/src/modules/transaction/actions.ts
+++ b/src/modules/transaction/actions.ts
@@ -119,10 +119,15 @@ export const REPLACE_TRANSACTION_REQUEST = '[Request] Replace Transaction'
 export const REPLACE_TRANSACTION_SUCCESS = '[Success] Replace Transaction'
 export const REPLACE_TRANSACTION_FAILURE = '[Failure] Replace Transaction'
 
-export const replaceTransactionRequest = (hash: string, nonce: number) =>
+export const replaceTransactionRequest = (
+  hash: string,
+  nonce: number,
+  address: string
+) =>
   action(REPLACE_TRANSACTION_REQUEST, {
     hash,
-    nonce
+    nonce,
+    address
   })
 
 export const replaceTransactionSuccess = (hash: string, replaceBy: string) =>


### PR DESCRIPTION
This PR does the following:
- Updates the fetch transaction mechanism to use the `from` address in the request instead of the wallet's address which might differ after connecting with other wallet.
- Updates the `handleReplaceTransactionRequest` handler to get the network provided on each loop to prevent request to a Metamask provider that is not connected at the time.