### PR TITLE
fix: Login Modal custom onConnect action

### DIFF
--- a/src/containers/LoginModal/LoginModal.tsx
+++ b/src/containers/LoginModal/LoginModal.tsx
@@ -36,8 +36,9 @@ export default class LoginModal extends React.PureComponent<Props, State> {
   }
 
   handleOnConnect = (loginType: LoginModalOptionType) => {
-    let providerType: ProviderType = toProviderType(loginType)
-    this.props.onConnect(providerType)
+    const onConnect = this.props.metadata?.onConnect ?? this.props.onConnect
+    const providerType: ProviderType = toProviderType(loginType)
+    onConnect(providerType)
   }
 
   getModalTranslations = (): LoginModalI18N | undefined => {
@@ -72,7 +73,7 @@ export default class LoginModal extends React.PureComponent<Props, State> {
         key={loginType}
         type={loginType}
         i18n={this.getOptionTranslations()}
-        onClick={() => this.handleOnConnect(loginType!)}
+        onClick={() => this.handleOnConnect(loginType)}
       />
     ) : null
   }

--- a/src/containers/LoginModal/LoginModal.types.ts
+++ b/src/containers/LoginModal/LoginModal.types.ts
@@ -7,8 +7,9 @@ import { ModalProps } from '../../providers/ModalProvider/ModalProvider.types'
 export type DefaultProps = { isLoading: boolean }
 
 export type Props = DefaultProps &
-  ModalProps &
+  Omit<ModalProps, 'metadata'> &
   LoginModalProps & {
+    metadata?: Metadata
     hasTranslations?: boolean
     onConnect: (providerType: ProviderType) => any
   }
@@ -18,6 +19,10 @@ export type State = {
 }
 
 export type OwnProps = Pick<Props, 'metadata'>
+
+export type Metadata = {
+  onConnect: (providerType: ProviderType) => any
+}
 
 export type MapStateProps = Pick<
   Props,

--- a/src/containers/SignInPage/SignInPage.container.ts
+++ b/src/containers/SignInPage/SignInPage.container.ts
@@ -22,8 +22,14 @@ const mapState = (state: any): MapStateProps => ({
   hasTranslations: isEnabled(state)
 })
 
-const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onConnect: () => dispatch(openModal('LoginModal'))
+const mapDispatch = (
+  dispatch: MapDispatch,
+  ownProps: SignInPageProps
+): MapDispatchProps => ({
+  onConnect: () =>
+    dispatch(
+      openModal('LoginModal', { onConnect: ownProps.handleLoginConnect })
+    )
 })
 
 const mergeProps = (

--- a/src/containers/SignInPage/SignInPage.types.ts
+++ b/src/containers/SignInPage/SignInPage.types.ts
@@ -1,9 +1,11 @@
 import { Dispatch } from 'redux'
+import { ProviderType } from '@dcl/schemas/dist/dapps/provider-type'
 import { SignInProps } from 'decentraland-ui/dist/components/SignIn/SignIn'
 import { openModal, OpenModalAction } from '../../modules/modal/actions'
 
 export type SignInPageProps = Omit<SignInProps, 'onConnect'> & {
   onConnect: () => ReturnType<typeof openModal>
+  handleLoginConnect?: (providerType: ProviderType) => any
   hasTranslations?: boolean
 }
 


### PR DESCRIPTION
This PR adds a handler: `handleLoginConnect`, allowing a custom `onConnect` action in the component: `LoginModal` that fulfills each unique login flow in the dApps.
