### PR TITLE
feat: Add non-retryable API errors mechanism for the BaseClient

### DIFF
--- a/src/lib/BaseClient.spec.ts
+++ b/src/lib/BaseClient.spec.ts
@@ -40,7 +40,7 @@ beforeEach(() => {
   jest.clearAllMocks()
 })
 
-describe('when the request fails', () => {
+describe('when the request fails with a server error', () => {
   beforeEach(() => {
     nock(urlTest)
       .get('/test')
@@ -147,6 +147,35 @@ describe('when the request fails', () => {
       expect(setTimeout).toHaveBeenCalledWith(
         expect.anything(),
         config.retryDelay
+      )
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+})
+
+describe('when the request fails with a client error non-retryable error', () => {
+  beforeEach(() => {
+    nock(urlTest)
+      .get('/test')
+      .reply(422, {})
+      .defaultReplyHeaders({
+        'Access-Control-Allow-Origin': '*'
+      })
+  })
+
+  describe.each([1, 3, 5])('and there is %s attempt left', retries => {
+    beforeEach(() => {
+      config = {
+        ...config,
+        retries,
+        nonRetryableStatuses: [422]
+      }
+      baseClient = new TestBaseClient(urlTest, config)
+    })
+
+    it('should not retry, but throw with the response error as soon as the request fails', async () => {
+      await expect(baseClient.performRequest('/test')).rejects.toThrowError(
+        'Request failed with status code 422'
       )
       expect(nock.isDone()).toBeTruthy()
     })

--- a/src/lib/BaseClient.spec.ts
+++ b/src/lib/BaseClient.spec.ts
@@ -153,7 +153,7 @@ describe('when the request fails with a server error', () => {
   })
 })
 
-describe('when the request fails with a client error non-retryable error', () => {
+describe('when the request fails with a client non-retryable error', () => {
   beforeEach(() => {
     nock(urlTest)
       .get('/test')

--- a/src/lib/BaseClient.ts
+++ b/src/lib/BaseClient.ts
@@ -4,6 +4,7 @@ import { ClientError } from './ClientError'
 
 const DEFAULT_RETRIES = 3
 const DEFAULT_RETRY_DELAY = 1000
+const DEFAULT_NON_RETRYABLE_STATUSES = [400, 401, 403, 404, 409, 422]
 const URL = globalThis?.URL ?? nodeURL.URL
 
 export type BaseClientConfig = {
@@ -12,12 +13,14 @@ export type BaseClientConfig = {
   retries?: number
   /** The delay between retries if the request fails */
   retryDelay?: number
+  nonRetryableStatuses?: number[]
 }
 
 export abstract class BaseClient {
   private readonly baseUrl: string
   private readonly retries: number
   private readonly retryDelay: number
+  private readonly nonRetryableStatuses: number[]
   private readonly identity:
     | AuthIdentity
     | ((...args: unknown[]) => AuthIdentity | undefined)
@@ -28,6 +31,7 @@ export abstract class BaseClient {
     this.identity = config?.identity
     this.retries = config?.retries ?? DEFAULT_RETRIES
     this.retryDelay = config?.retryDelay ?? DEFAULT_RETRY_DELAY
+    this.nonRetryableStatuses = config?.nonRetryableStatuses ?? DEFAULT_NON_RETRYABLE_STATUSES
   }
 
   private sleep = (delay: number) =>
@@ -72,13 +76,12 @@ export abstract class BaseClient {
         } else {
           return parsedResponse as T
         }
-
       } catch (error) {
         console.error(
           `[API] HTTP request failed: ${error.message || ''}`,
           error
         )
-        if (this.retries === attempt) throw error
+        if (this.retries === attempt || (error.status && this.nonRetryableStatuses.includes(error.status))) throw error
         await this.sleep(this.retryDelay)
       }
     }

--- a/src/lib/BaseClient.ts
+++ b/src/lib/BaseClient.ts
@@ -13,6 +13,7 @@ export type BaseClientConfig = {
   retries?: number
   /** The delay between retries if the request fails */
   retryDelay?: number
+  /** The status numbers that would not be retried */
   nonRetryableStatuses?: number[]
 }
 


### PR DESCRIPTION
This PR refactors the retrial mechanism in the `BaseClient`.

If the API will throw the same error every time the client makes the exactly same request, the `BaseClient` implementation should not try to repeat the failed request.