### PR TITLE
fix: Choose on connect in container

### DIFF
--- a/src/containers/LoginModal/LoginModal.container.ts
+++ b/src/containers/LoginModal/LoginModal.container.ts
@@ -13,6 +13,7 @@ import {
   MapDispatchProps
 } from './LoginModal.types'
 import LoginModal from './LoginModal'
+import { OwnProps } from './LoginModal.types'
 
 const mapState = (state: any): MapStateProps => ({
   hasError: !!getError(state),
@@ -20,22 +21,13 @@ const mapState = (state: any): MapStateProps => ({
   hasTranslations: isEnabled(state)
 })
 
-const mapDispatch = (dispatch: MapDispatch): MapDispatchProps => ({
-  onConnect: providerType => dispatch(enableWalletRequest(providerType))
+const mapDispatch = (
+  dispatch: MapDispatch,
+  ownProps: OwnProps
+): MapDispatchProps => ({
+  onConnect:
+    ownProps.metadata?.onConnect ??
+    (providerType => dispatch(enableWalletRequest(providerType)))
 })
 
-const mergeProps = (
-  stateProps: MapStateProps,
-  dispatchProps: MapDispatchProps,
-  ownProps: LoginModalProps
-): LoginModalProps => ({
-  ...stateProps,
-  ...dispatchProps,
-  ...ownProps
-})
-
-export default connect(
-  mapState,
-  mapDispatch,
-  mergeProps
-)(LoginModal)
+export default connect(mapState, mapDispatch)(LoginModal)

--- a/src/containers/LoginModal/LoginModal.tsx
+++ b/src/containers/LoginModal/LoginModal.tsx
@@ -36,7 +36,7 @@ export default class LoginModal extends React.PureComponent<Props, State> {
   }
 
   handleOnConnect = (loginType: LoginModalOptionType) => {
-    const onConnect = this.props.metadata?.onConnect ?? this.props.onConnect
+    const { onConnect } = this.props
     const providerType: ProviderType = toProviderType(loginType)
     onConnect(providerType)
   }


### PR DESCRIPTION
This PR changes the way the onConnect is passed to the component by choosing in the container wether to use the one coming from the metadata.