### PR TITLE
feat: add authorization flow saga

### DIFF
--- a/src/modules/authorization/actions.spec.ts
+++ b/src/modules/authorization/actions.spec.ts
@@ -8,10 +8,15 @@ import {
 } from './actions'
 import { Authorization, AuthorizationAction } from './types'
 
+let authorization: Authorization
+
 describe('authorization flow actions', () => {
+  beforeEach(() => {
+    authorization = {} as Authorization
+  })
+
   describe('when calling authorizationFlowRequest action', () => {
     it('should return the correct action type and payload', () => {
-      const authorization = {} as Authorization
       const authorizationAction = AuthorizationAction.GRANT
       const allowance = '10'
       expect(
@@ -29,7 +34,6 @@ describe('authorization flow actions', () => {
 
   describe('when calling authorizationFlowSuccess action', () => {
     it('should return the correct action type and payload', () => {
-      const authorization = {} as Authorization
       expect(authorizationFlowSuccess(authorization)).toEqual({
         type: AUTHORIZATION_FLOW_SUCCESS,
         payload: {
@@ -41,7 +45,6 @@ describe('authorization flow actions', () => {
 
   describe('when calling authorizationFlowFailure action', () => {
     it('should return the correct action type and payload', () => {
-      const authorization = {} as Authorization
       const error = 'some error'
       expect(authorizationFlowFailure(authorization, error)).toEqual({
         type: AUTHORIZATION_FLOW_FAILURE,

--- a/src/modules/authorization/actions.spec.ts
+++ b/src/modules/authorization/actions.spec.ts
@@ -1,0 +1,55 @@
+import {
+  AUTHORIZATION_FLOW_FAILURE,
+  AUTHORIZATION_FLOW_REQUEST,
+  AUTHORIZATION_FLOW_SUCCESS,
+  authorizationFlowFailure,
+  authorizationFlowRequest,
+  authorizationFlowSuccess
+} from './actions'
+import { Authorization, AuthorizationAction } from './types'
+
+describe('authorization flow actions', () => {
+  describe('when calling authorizationFlowRequest action', () => {
+    it('should return the correct action type and payload', () => {
+      const authorization = {} as Authorization
+      const authorizationAction = AuthorizationAction.GRANT
+      const allowance = '10'
+      expect(
+        authorizationFlowRequest(authorization, authorizationAction, allowance)
+      ).toEqual({
+        type: AUTHORIZATION_FLOW_REQUEST,
+        payload: {
+          authorization,
+          authorizationAction,
+          allowance
+        }
+      })
+    })
+  })
+
+  describe('when calling authorizationFlowSuccess action', () => {
+    it('should return the correct action type and payload', () => {
+      const authorization = {} as Authorization
+      expect(authorizationFlowSuccess(authorization)).toEqual({
+        type: AUTHORIZATION_FLOW_SUCCESS,
+        payload: {
+          authorization
+        }
+      })
+    })
+  })
+
+  describe('when calling authorizationFlowFailure action', () => {
+    it('should return the correct action type and payload', () => {
+      const authorization = {} as Authorization
+      const error = 'some error'
+      expect(authorizationFlowFailure(authorization, error)).toEqual({
+        type: AUTHORIZATION_FLOW_FAILURE,
+        payload: {
+          authorization,
+          error
+        }
+      })
+    })
+  })
+})

--- a/src/modules/authorization/actions.ts
+++ b/src/modules/authorization/actions.ts
@@ -1,7 +1,7 @@
 import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { action } from 'typesafe-actions'
 import { buildTransactionPayload } from '../transaction/utils'
-import { Authorization } from './types'
+import { Authorization, AuthorizationAction } from './types'
 
 // Fetch authorizations
 
@@ -98,3 +98,39 @@ export const revokeTokenFailure = (
 export type RevokeTokenRequestAction = ReturnType<typeof revokeTokenRequest>
 export type RevokeTokenSuccessAction = ReturnType<typeof revokeTokenSuccess>
 export type RevokeTokenFailureAction = ReturnType<typeof revokeTokenFailure>
+
+// Authorization Flow
+export const AUTHORIZATION_FLOW_REQUEST = '[Request] Authorization Flow'
+export const AUTHORIZATION_FLOW_SUCCESS = '[Success] Authorization Flow'
+export const AUTHORIZATION_FLOW_FAILURE = '[Failure] Authorization Flow'
+
+export const authorizationFlowRequest = (
+  authorization: Authorization,
+  authorizationAction: AuthorizationAction,
+  allowance?: string
+) =>
+  action(AUTHORIZATION_FLOW_REQUEST, {
+    authorization,
+    authorizationAction,
+    allowance
+  })
+
+export const authorizationFlowSuccess = (authorization: Authorization) =>
+  action(AUTHORIZATION_FLOW_SUCCESS, {
+    authorization
+  })
+
+export const authorizationFlowFailure = (
+  authorization: Authorization,
+  error: string
+) => action(AUTHORIZATION_FLOW_FAILURE, { authorization, error })
+
+export type AuthorizationFlowRequestAction = ReturnType<
+  typeof authorizationFlowRequest
+>
+export type AuthorizationFlowSuccessAction = ReturnType<
+  typeof authorizationFlowSuccess
+>
+export type AuthorizationFlowFailureAction = ReturnType<
+  typeof authorizationFlowFailure
+>

--- a/src/modules/authorization/reducer.spec.ts
+++ b/src/modules/authorization/reducer.spec.ts
@@ -9,10 +9,13 @@ import {
   revokeTokenSuccess,
   revokeTokenRequest,
   grantTokenRequest,
-  grantTokenSuccess
+  grantTokenSuccess,
+  authorizationFlowRequest,
+  authorizationFlowSuccess,
+  authorizationFlowFailure
 } from './actions'
 import { authorizationReducer, INITIAL_STATE } from './reducer'
-import { Authorization } from './types'
+import { Authorization, AuthorizationAction } from './types'
 
 describe.each([
   {
@@ -80,4 +83,109 @@ describe.each([
       )
     })
   }
+})
+
+describe('authorization flow actions', () => {
+  describe('when handling AUTHORIZATION_FLOW_REQUEST action', () => {
+    it('should add action to loading array', () => {
+      const requestAction = authorizationFlowRequest(
+        {} as Authorization,
+        AuthorizationAction.GRANT
+      )
+      expect(authorizationReducer(INITIAL_STATE, requestAction)).toEqual(
+        expect.objectContaining({
+          loading: [requestAction]
+        })
+      )
+    })
+
+    it('should remove error', () => {
+      const initialStateWithError = {
+        ...INITIAL_STATE,
+        authorizationFlowError: 'Some error'
+      }
+
+      expect(
+        authorizationReducer(
+          initialStateWithError,
+          authorizationFlowRequest(
+            {} as Authorization,
+            AuthorizationAction.GRANT
+          )
+        )
+      ).toEqual(
+        expect.objectContaining({
+          authorizationFlowError: null
+        })
+      )
+    })
+  })
+
+  describe('when handling AUTHORIZATION_FLOW_SUCCESS action', () => {
+    it('should remove action from loading array', () => {
+      const successAction = authorizationFlowSuccess({} as Authorization)
+      const initialStateWithLoading = {
+        ...INITIAL_STATE,
+        loading: [successAction]
+      }
+      expect(
+        authorizationReducer(initialStateWithLoading, successAction)
+      ).toEqual(
+        expect.objectContaining({
+          loading: []
+        })
+      )
+    })
+
+    it('should remove error', () => {
+      const initialStateWithError = {
+        ...INITIAL_STATE,
+        authorizationFlowError: 'Some error'
+      }
+
+      expect(
+        authorizationReducer(
+          initialStateWithError,
+          authorizationFlowSuccess({} as Authorization)
+        )
+      ).toEqual(
+        expect.objectContaining({
+          authorizationFlowError: null
+        })
+      )
+    })
+  })
+
+  describe('when handling AUTHORIZATION_FLOW_FAILURE action', () => {
+    it('should remove action from loading array', () => {
+      const failureAction = authorizationFlowFailure(
+        {} as Authorization,
+        'an error'
+      )
+      const initialStateWithLoading = {
+        ...INITIAL_STATE,
+        loading: [failureAction]
+      }
+      expect(
+        authorizationReducer(initialStateWithLoading, failureAction)
+      ).toEqual(
+        expect.objectContaining({
+          loading: []
+        })
+      )
+    })
+
+    it('should add error', () => {
+      expect(
+        authorizationReducer(
+          INITIAL_STATE,
+          authorizationFlowFailure({} as Authorization, 'an error')
+        )
+      ).toEqual(
+        expect.objectContaining({
+          authorizationFlowError: 'an error'
+        })
+      )
+    })
+  })
 })

--- a/src/modules/authorization/reducer.spec.ts
+++ b/src/modules/authorization/reducer.spec.ts
@@ -12,9 +12,16 @@ import {
   grantTokenSuccess,
   authorizationFlowRequest,
   authorizationFlowSuccess,
-  authorizationFlowFailure
+  authorizationFlowFailure,
+  AuthorizationFlowRequestAction,
+  AuthorizationFlowFailureAction,
+  AuthorizationFlowSuccessAction
 } from './actions'
-import { authorizationReducer, INITIAL_STATE } from './reducer'
+import {
+  authorizationReducer,
+  AuthorizationState,
+  INITIAL_STATE
+} from './reducer'
 import { Authorization, AuthorizationAction } from './types'
 
 describe.each([
@@ -86,34 +93,34 @@ describe.each([
 })
 
 describe('authorization flow actions', () => {
+  let initialState: AuthorizationState
+  let action:
+    | AuthorizationFlowRequestAction
+    | AuthorizationFlowFailureAction
+    | AuthorizationFlowSuccessAction
+
   describe('when handling AUTHORIZATION_FLOW_REQUEST action', () => {
-    it('should add action to loading array', () => {
-      const requestAction = authorizationFlowRequest(
+    beforeEach(() => {
+      action = authorizationFlowRequest(
         {} as Authorization,
         AuthorizationAction.GRANT
       )
-      expect(authorizationReducer(INITIAL_STATE, requestAction)).toEqual(
+      initialState = {
+        ...INITIAL_STATE,
+        authorizationFlowError: 'test error'
+      }
+    })
+
+    it('should add action to loading array', () => {
+      expect(authorizationReducer(initialState, action)).toEqual(
         expect.objectContaining({
-          loading: [requestAction]
+          loading: [action]
         })
       )
     })
 
     it('should remove error', () => {
-      const initialStateWithError = {
-        ...INITIAL_STATE,
-        authorizationFlowError: 'Some error'
-      }
-
-      expect(
-        authorizationReducer(
-          initialStateWithError,
-          authorizationFlowRequest(
-            {} as Authorization,
-            AuthorizationAction.GRANT
-          )
-        )
-      ).toEqual(
+      expect(authorizationReducer(initialState, action)).toEqual(
         expect.objectContaining({
           authorizationFlowError: null
         })
@@ -122,15 +129,17 @@ describe('authorization flow actions', () => {
   })
 
   describe('when handling AUTHORIZATION_FLOW_SUCCESS action', () => {
-    it('should remove action from loading array', () => {
-      const successAction = authorizationFlowSuccess({} as Authorization)
-      const initialStateWithLoading = {
+    beforeEach(() => {
+      action = authorizationFlowSuccess({} as Authorization)
+      initialState = {
         ...INITIAL_STATE,
-        loading: [successAction]
+        loading: [action],
+        authorizationFlowError: 'test error'
       }
-      expect(
-        authorizationReducer(initialStateWithLoading, successAction)
-      ).toEqual(
+    })
+
+    it('should remove action from loading array', () => {
+      expect(authorizationReducer(initialState, action)).toEqual(
         expect.objectContaining({
           loading: []
         })
@@ -138,17 +147,7 @@ describe('authorization flow actions', () => {
     })
 
     it('should remove error', () => {
-      const initialStateWithError = {
-        ...INITIAL_STATE,
-        authorizationFlowError: 'Some error'
-      }
-
-      expect(
-        authorizationReducer(
-          initialStateWithError,
-          authorizationFlowSuccess({} as Authorization)
-        )
-      ).toEqual(
+      expect(authorizationReducer(initialState, action)).toEqual(
         expect.objectContaining({
           authorizationFlowError: null
         })
@@ -157,18 +156,17 @@ describe('authorization flow actions', () => {
   })
 
   describe('when handling AUTHORIZATION_FLOW_FAILURE action', () => {
-    it('should remove action from loading array', () => {
-      const failureAction = authorizationFlowFailure(
-        {} as Authorization,
-        'an error'
-      )
-      const initialStateWithLoading = {
+    beforeEach(() => {
+      action = authorizationFlowFailure({} as Authorization, 'an error')
+      initialState = {
         ...INITIAL_STATE,
-        loading: [failureAction]
+        loading: [action],
+        authorizationFlowError: null
       }
-      expect(
-        authorizationReducer(initialStateWithLoading, failureAction)
-      ).toEqual(
+    })
+
+    it('should remove action from loading array', () => {
+      expect(authorizationReducer(initialState, action)).toEqual(
         expect.objectContaining({
           loading: []
         })
@@ -176,12 +174,7 @@ describe('authorization flow actions', () => {
     })
 
     it('should add error', () => {
-      expect(
-        authorizationReducer(
-          INITIAL_STATE,
-          authorizationFlowFailure({} as Authorization, 'an error')
-        )
-      ).toEqual(
+      expect(authorizationReducer(initialState, action)).toEqual(
         expect.objectContaining({
           authorizationFlowError: 'an error'
         })

--- a/src/modules/authorization/reducer.ts
+++ b/src/modules/authorization/reducer.ts
@@ -21,7 +21,13 @@ import {
   GRANT_TOKEN_FAILURE,
   REVOKE_TOKEN_REQUEST,
   REVOKE_TOKEN_SUCCESS,
-  REVOKE_TOKEN_FAILURE
+  REVOKE_TOKEN_FAILURE,
+  AUTHORIZATION_FLOW_FAILURE,
+  AuthorizationFlowRequestAction,
+  AuthorizationFlowSuccessAction,
+  AuthorizationFlowFailureAction,
+  AUTHORIZATION_FLOW_REQUEST,
+  AUTHORIZATION_FLOW_SUCCESS
 } from './actions'
 import { Authorization } from './types'
 import { areEqual } from './utils'
@@ -30,12 +36,14 @@ export type AuthorizationState = {
   data: Authorization[]
   loading: LoadingState
   error: string | null
+  authorizationFlowError: string | null
 }
 
 export const INITIAL_STATE = {
   data: [],
   loading: [],
-  error: null
+  error: null,
+  authorizationFlowError: null
 }
 
 type AuthorizationReducerAction =
@@ -49,6 +57,9 @@ type AuthorizationReducerAction =
   | RevokeTokenSuccessAction
   | RevokeTokenFailureAction
   | FetchTransactionSuccessAction
+  | AuthorizationFlowRequestAction
+  | AuthorizationFlowSuccessAction
+  | AuthorizationFlowFailureAction
 
 export function authorizationReducer(
   state: AuthorizationState = INITIAL_STATE,
@@ -66,6 +77,19 @@ export function authorizationReducer(
         loading: loadingReducer(state.loading, action)
       }
     }
+    case AUTHORIZATION_FLOW_REQUEST:
+    case AUTHORIZATION_FLOW_SUCCESS:
+      return {
+        ...state,
+        authorizationFlowError: null,
+        loading: loadingReducer(state.loading, action)
+      }
+    case AUTHORIZATION_FLOW_FAILURE:
+      return {
+        ...state,
+        authorizationFlowError: action.payload.error,
+        loading: loadingReducer(state.loading, action)
+      }
     case FETCH_AUTHORIZATIONS_SUCCESS: {
       const { authorizations } = action.payload
 

--- a/src/modules/authorization/sagas.spec.ts
+++ b/src/modules/authorization/sagas.spec.ts
@@ -1,0 +1,248 @@
+import { expectSaga } from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import { put, call, select } from 'redux-saga/effects'
+import { ContractName } from 'decentraland-transactions'
+import { ChainId } from '@dcl/schemas'
+import { fetchTransactionSuccess } from '../transaction/actions'
+import { Transaction } from '../transaction/types'
+import { waitForTx } from '../transaction/utils'
+import { getData } from './selectors'
+import { AuthorizationError } from './utils'
+import { createAuthorizationSaga } from './sagas'
+import {
+  authorizationFlowFailure,
+  authorizationFlowRequest,
+  authorizationFlowSuccess,
+  fetchAuthorizationsFailure,
+  fetchAuthorizationsRequest,
+  fetchAuthorizationsSuccess,
+  grantTokenFailure,
+  grantTokenRequest,
+  grantTokenSuccess,
+  revokeTokenFailure,
+  revokeTokenRequest,
+  revokeTokenSuccess
+} from './actions'
+import { Authorization, AuthorizationAction, AuthorizationType } from './types'
+
+const authorizationSaga = createAuthorizationSaga()
+
+const authorization: Authorization = {
+  type: AuthorizationType.ALLOWANCE,
+  address: '0x9c76ae45c36a4da3801a5ba387bbfa3c073ecae2',
+  contractAddress: '0x9c76ae45c36a4da3801a5ba387bbfa3c073ecae3',
+  authorizedAddress: '0x9c76ae45c36a4da3801a5ba387bbfa3c073ecae4',
+  contractName: ContractName.MANAToken,
+  chainId: ChainId.ETHEREUM_GOERLI
+}
+
+describe('handleAuthorizationFlowRequest', () => {
+  describe('when granting a token', () => {
+    describe('and authorization flow finishes successfully', () => {
+      it('should put success action', () => {
+        return expectSaga(authorizationSaga)
+          .provide([
+            [put(fetchAuthorizationsRequest([authorization])), undefined],
+            [put(grantTokenRequest(authorization)), undefined],
+            [call(waitForTx, 'tx-hash'), undefined],
+            [select(getData), [{ ...authorization, allowance: '10000' }]]
+          ])
+          .put(authorizationFlowSuccess(authorization))
+          .dispatch(
+            authorizationFlowRequest(
+              authorization,
+              AuthorizationAction.GRANT,
+              '10'
+            )
+          )
+          .dispatch(
+            grantTokenSuccess(authorization, authorization.chainId, 'tx-hash')
+          )
+          .dispatch(
+            fetchAuthorizationsSuccess([
+              [authorization, { ...authorization, allowance: '10000' }]
+            ])
+          )
+          .dispatch(fetchTransactionSuccess({ hash: 'tx-hash' } as Transaction))
+          .run({ silenceTimeout: true })
+      })
+    })
+
+    describe('and grant token transaction fails', () => {
+      it('should put failure action', () => {
+        const error = new Error('an error occur')
+        return expectSaga(authorizationSaga)
+          .provide([
+            [put(grantTokenRequest(authorization)), undefined],
+            [call(waitForTx, 'tx-hash'), undefined],
+            [put(fetchAuthorizationsRequest([authorization])), undefined],
+            [
+              matchers.select(getData),
+              [{ ...authorization, allowance: '10000' }]
+            ]
+          ])
+          .put(authorizationFlowFailure(authorization, error.message))
+          .dispatch(
+            authorizationFlowRequest(
+              authorization,
+              AuthorizationAction.GRANT,
+              '10'
+            )
+          )
+          .dispatch(grantTokenFailure(authorization, error.message))
+          .run({ silenceTimeout: true })
+      })
+    })
+
+    describe('and fetch authorizations action fails', () => {
+      it('should put failure action with correct error message', () => {
+        const error = new Error('authorizations fetch error')
+        return expectSaga(authorizationSaga)
+          .provide([
+            [put(grantTokenRequest(authorization)), undefined],
+            [call(waitForTx, 'tx-hash'), undefined],
+            [put(fetchAuthorizationsRequest([authorization])), undefined],
+            [select(getData), [{ ...authorization, allowance: '10000' }]]
+          ])
+          .put(authorizationFlowFailure(authorization, error.message))
+          .dispatch(
+            authorizationFlowRequest(
+              authorization,
+              AuthorizationAction.GRANT,
+              '10'
+            )
+          )
+          .dispatch(
+            grantTokenSuccess(authorization, authorization.chainId, 'tx-hash')
+          )
+          .dispatch(fetchTransactionSuccess({ hash: 'tx-hash' } as Transaction))
+          .dispatch(fetchAuthorizationsFailure([], error.message))
+          .run({ silenceTimeout: true })
+      })
+    })
+
+    describe('and user sets an allowance smaller than the required value', () => {
+      it('should put failure action with correct error message', () => {
+        return expectSaga(authorizationSaga)
+          .provide([
+            [put(grantTokenRequest(authorization)), undefined],
+            [call(waitForTx, 'tx-hash'), undefined],
+            [put(fetchAuthorizationsRequest([authorization])), undefined],
+            [select(getData), [{ ...authorization, allowance: '1' }]]
+          ])
+          .put(
+            authorizationFlowFailure(
+              authorization,
+              AuthorizationError.INSUFFICIENT_ALLOWANCE
+            )
+          )
+          .dispatch(
+            authorizationFlowRequest(
+              authorization,
+              AuthorizationAction.GRANT,
+              '10'
+            )
+          )
+          .dispatch(
+            grantTokenSuccess(authorization, authorization.chainId, 'tx-hash')
+          )
+          .dispatch(fetchTransactionSuccess({ hash: 'tx-hash' } as Transaction))
+          .dispatch(fetchAuthorizationsSuccess([]))
+          .run({ silenceTimeout: true })
+      })
+    })
+  })
+
+  describe('when revoking a token', () => {
+    describe('and authorization flow finishes successfully', () => {
+      it('should put success action', () => {
+        return expectSaga(authorizationSaga)
+          .provide([
+            [put(revokeTokenRequest(authorization)), undefined],
+            [call(waitForTx, 'tx-hash'), undefined],
+            [put(fetchAuthorizationsRequest([authorization])), undefined],
+            [select(getData), []]
+          ])
+          .put(authorizationFlowSuccess(authorization))
+          .dispatch(
+            authorizationFlowRequest(authorization, AuthorizationAction.REVOKE)
+          )
+          .dispatch(
+            revokeTokenSuccess(authorization, authorization.chainId, 'tx-hash')
+          )
+          .dispatch(fetchAuthorizationsSuccess([[authorization, null]]))
+          .dispatch(fetchTransactionSuccess({ hash: 'tx-hash' } as Transaction))
+          .run({ silenceTimeout: true })
+      })
+    })
+
+    describe('and revoke token transaction fails', () => {
+      it('should put failure action with correct error message', () => {
+        const error = new Error('an error occur')
+        return expectSaga(authorizationSaga)
+          .provide([
+            [put(revokeTokenRequest(authorization)), undefined],
+            [call(waitForTx, 'tx-hash'), undefined],
+            [put(fetchAuthorizationsRequest([authorization])), undefined],
+            [select(getData), []]
+          ])
+          .put(authorizationFlowFailure(authorization, error.message))
+          .dispatch(
+            authorizationFlowRequest(authorization, AuthorizationAction.REVOKE)
+          )
+          .dispatch(revokeTokenFailure(authorization, error.message))
+          .run({ silenceTimeout: true })
+      })
+    })
+
+    describe('and fetch authorizations action fails', () => {
+      it('should put failure action with correct error message', () => {
+        const error = new Error('authorizations fetch error')
+        return expectSaga(authorizationSaga)
+          .provide([
+            [put(revokeTokenRequest(authorization)), undefined],
+            [call(waitForTx, 'tx-hash'), undefined],
+            [put(fetchAuthorizationsRequest([authorization])), undefined],
+            [select(getData), []]
+          ])
+          .put(authorizationFlowFailure(authorization, error.message))
+          .dispatch(
+            authorizationFlowRequest(authorization, AuthorizationAction.REVOKE)
+          )
+          .dispatch(
+            revokeTokenSuccess(authorization, authorization.chainId, 'tx-hash')
+          )
+          .dispatch(fetchTransactionSuccess({ hash: 'tx-hash' } as Transaction))
+          .dispatch(fetchAuthorizationsFailure([], error.message))
+          .run({ silenceTimeout: true })
+      })
+    })
+
+    describe('and user sets an allowance higher than 0', () => {
+      it('should put failure action with correct error message', () => {
+        return expectSaga(authorizationSaga)
+          .provide([
+            [put(fetchAuthorizationsRequest([authorization])), undefined],
+            [put(revokeTokenRequest(authorization)), undefined],
+            [call(waitForTx, 'tx-hash'), undefined],
+            [select(getData), [{ ...authorization, allowance: '1' }]]
+          ])
+          .put(
+            authorizationFlowFailure(
+              authorization,
+              AuthorizationError.REVOKE_FAILED
+            )
+          )
+          .dispatch(
+            authorizationFlowRequest(authorization, AuthorizationAction.REVOKE)
+          )
+          .dispatch(
+            revokeTokenSuccess(authorization, authorization.chainId, 'tx-hash')
+          )
+          .dispatch(fetchTransactionSuccess({ hash: 'tx-hash' } as Transaction))
+          .dispatch(fetchAuthorizationsSuccess([]))
+          .run({ silenceTimeout: true })
+      })
+    })
+  })
+})

--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -1,10 +1,18 @@
-import { put, call, takeEvery } from 'redux-saga/effects'
+import { put, call, takeEvery, take, select, race } from 'redux-saga/effects'
 import { providers } from '@0xsequence/multicall'
 import { ethers } from 'ethers'
 import { Provider } from 'decentraland-connect/dist/types'
 import { ContractData, getContract } from 'decentraland-transactions'
 import { getNetworkProvider } from '../../lib/eth'
-import { getTokenAmountToApprove, isValidType } from './utils'
+import { sendTransaction } from '../wallet/utils/sendTransaction'
+import { getTransactionFromAction, waitForTx } from '../transaction/utils'
+import {
+  AuthorizationError,
+  getTokenAmountToApprove,
+  hasAuthorization,
+  hasAuthorizationAndEnoughAllowance,
+  isValidType
+} from './utils'
 import {
   fetchAuthorizationsSuccess,
   fetchAuthorizationsFailure,
@@ -17,10 +25,28 @@ import {
   revokeTokenSuccess,
   revokeTokenFailure,
   RevokeTokenRequestAction,
-  REVOKE_TOKEN_REQUEST
+  REVOKE_TOKEN_REQUEST,
+  AuthorizationFlowRequestAction,
+  AUTHORIZATION_FLOW_REQUEST,
+  authorizationFlowFailure,
+  authorizationFlowSuccess,
+  fetchAuthorizationsRequest,
+  FETCH_AUTHORIZATIONS_SUCCESS,
+  REVOKE_TOKEN_SUCCESS,
+  GRANT_TOKEN_SUCCESS,
+  revokeTokenRequest,
+  grantTokenRequest,
+  GrantTokenSuccessAction,
+  RevokeTokenSuccessAction,
+  REVOKE_TOKEN_FAILURE,
+  GRANT_TOKEN_FAILURE,
+  RevokeTokenFailureAction,
+  FETCH_AUTHORIZATIONS_FAILURE,
+  FetchAuthorizationsSuccessAction,
+  FetchAuthorizationsFailureAction
 } from './actions'
 import { Authorization, AuthorizationAction, AuthorizationType } from './types'
-import { sendTransaction } from '../wallet/utils/sendTransaction'
+import { getData } from './selectors'
 
 export function createAuthorizationSaga() {
   return function* authorizationSaga() {
@@ -30,6 +56,7 @@ export function createAuthorizationSaga() {
     )
     yield takeEvery(GRANT_TOKEN_REQUEST, handleGrantTokenRequest)
     yield takeEvery(REVOKE_TOKEN_REQUEST, handleRevokeTokenRequest)
+    yield takeEvery(AUTHORIZATION_FLOW_REQUEST, handleAuthorizationFlowRequest)
   }
 
   function* handleFetchAuthorizationsRequest(
@@ -143,6 +170,7 @@ export function createAuthorizationSaga() {
 
   function* handleRevokeTokenRequest(action: RevokeTokenRequestAction) {
     const { authorization } = action.payload
+    console.log('HOLAAA')
     try {
       const txHash: string = yield call(() =>
         changeAuthorization(authorization, AuthorizationAction.REVOKE)
@@ -152,6 +180,91 @@ export function createAuthorizationSaga() {
       )
     } catch (error) {
       yield put(revokeTokenFailure(authorization, error.message))
+    }
+  }
+
+  function* handleAuthorizationFlowRequest(
+    action: AuthorizationFlowRequestAction
+  ) {
+    const { authorizationAction, authorization, allowance } = action.payload
+    const isRevoke = authorizationAction === AuthorizationAction.REVOKE
+    const tokenRequest = isRevoke
+      ? revokeTokenRequest(authorization)
+      : grantTokenRequest(authorization)
+    const TOKEN_SUCCESS = isRevoke ? REVOKE_TOKEN_SUCCESS : GRANT_TOKEN_SUCCESS
+    const TOKEN_FAILURE = isRevoke ? REVOKE_TOKEN_FAILURE : GRANT_TOKEN_FAILURE
+
+    yield put(tokenRequest)
+
+    try {
+      const {
+        success,
+        failure
+      }: {
+        success: RevokeTokenSuccessAction | GrantTokenSuccessAction | undefined
+        failure: RevokeTokenFailureAction | RevokeTokenFailureAction | undefined
+      } = yield race({
+        success: take(TOKEN_SUCCESS),
+        failure: take(TOKEN_FAILURE)
+      })
+      if (failure) {
+        throw new Error(failure.payload.error)
+      }
+      const txHash = getTransactionFromAction(success!).hash
+
+      yield call(waitForTx, txHash)
+
+      yield put(fetchAuthorizationsRequest([authorization]))
+
+      const {
+        fetchFailure
+      }: {
+        fetchSuccess: FetchAuthorizationsSuccessAction | undefined
+        fetchFailure: FetchAuthorizationsFailureAction | undefined
+      } = yield race({
+        fetchSuccess: take(FETCH_AUTHORIZATIONS_SUCCESS),
+        fetchFailure: take(FETCH_AUTHORIZATIONS_FAILURE)
+      })
+
+      if (fetchFailure) {
+        throw new Error(
+          fetchFailure.payload.error ||
+            AuthorizationError.FETCH_AUTHORIZATIONS_FAILURE
+        )
+      }
+      const authorizations: Authorization[] = yield select(getData)
+
+      if (
+        authorizationAction === AuthorizationAction.REVOKE &&
+        hasAuthorization(authorizations, authorization)
+      ) {
+        throw new Error(AuthorizationError.REVOKE_FAILED)
+      }
+
+      if (authorizationAction === AuthorizationAction.GRANT) {
+        if (
+          authorization.type === AuthorizationType.ALLOWANCE &&
+          allowance &&
+          !hasAuthorizationAndEnoughAllowance(
+            authorizations,
+            authorization,
+            allowance
+          )
+        ) {
+          throw new Error(AuthorizationError.INSUFFICIENT_ALLOWANCE)
+        }
+
+        if (
+          authorization.type === AuthorizationType.APPROVAL &&
+          !hasAuthorization(authorizations, authorization)
+        ) {
+          throw new Error(AuthorizationError.GRANT_FAILED)
+        }
+      }
+
+      yield put(authorizationFlowSuccess(authorization))
+    } catch (error) {
+      yield put(authorizationFlowFailure(authorization, error.message))
     }
   }
 

--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -209,7 +209,9 @@ export function createAuthorizationSaga() {
       if (failure) {
         throw new Error(failure.payload.error)
       }
-      const txHash = getTransactionFromAction(success!).hash
+      const txHash = getTransactionFromAction(
+        success as RevokeTokenSuccessAction | GrantTokenSuccessAction
+      ).hash
 
       yield call(waitForTx, txHash)
 

--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -170,7 +170,6 @@ export function createAuthorizationSaga() {
 
   function* handleRevokeTokenRequest(action: RevokeTokenRequestAction) {
     const { authorization } = action.payload
-    console.log('HOLAAA')
     try {
       const txHash: string = yield call(() =>
         changeAuthorization(authorization, AuthorizationAction.REVOKE)

--- a/src/modules/authorization/selectors.spec.ts
+++ b/src/modules/authorization/selectors.spec.ts
@@ -1,0 +1,16 @@
+import { INITIAL_STATE } from './reducer'
+import { getAuthorizationFlowError } from './selectors'
+
+describe('when getting authorization flow error', () => {
+  it('should return the correct value', () => {
+    const error = 'an authorization flow error message'
+    expect(
+      getAuthorizationFlowError({
+        authorization: {
+          ...INITIAL_STATE,
+          authorizationFlowError: error
+        }
+      })
+    ).toEqual(error)
+  })
+})

--- a/src/modules/authorization/selectors.ts
+++ b/src/modules/authorization/selectors.ts
@@ -10,6 +10,8 @@ export const getData = (state: any) => getState(state).data
 export const getLoading = (state: any) => getState(state).loading
 export const isLoading = (state: any) => getLoading(state).length > 0
 export const getError = (state: any) => getState(state).error
+export const getAuthorizationFlowError = (state: any) =>
+  getState(state).authorizationFlowError
 
 export const getTransactions = (state: any) =>
   getTransactionsByType(state, getAddress(state) || '', GRANT_TOKEN_SUCCESS)

--- a/src/modules/authorization/utils.ts
+++ b/src/modules/authorization/utils.ts
@@ -1,6 +1,13 @@
 import { ethers } from 'ethers'
 import { Authorization, AuthorizationType } from './types'
 
+export enum AuthorizationError {
+  REVOKE_FAILED = 'revoke-failed-error',
+  GRANT_FAILED = 'grant-failed-error',
+  INSUFFICIENT_ALLOWANCE = 'insufficient-allowance',
+  FETCH_AUTHORIZATIONS_FAILURE = 'fetch-authorizations-failure'
+}
+
 export function getTokenAmountToApprove(): ethers.BigNumber {
   return ethers.BigNumber.from(2)
     .pow(256)


### PR DESCRIPTION
Add new actions and saga to handle the whole authorization flow
- Grant/Revoke token
- Wait for transaction to be confirmed
- Fetch authorizations
- Check that the authorization was done correctly