### PR TITLE
fix: authorization error reset on authorizations success

### DIFF
--- a/src/modules/authorization/reducer.ts
+++ b/src/modules/authorization/reducer.ts
@@ -110,6 +110,7 @@ export function authorizationReducer(
       }, [] as Authorization[])
 
       return {
+        ...state,
         loading: loadingReducer(state.loading, action),
         error: null,
         // concat the base and new authorizations, without duplications and removing the ones that are now null.


### PR DESCRIPTION
Do not reset authorizationError value when dispatching AUTHORIZATIONS_SUCCESS action