### PR TITLE
fix: Include Refunded as a final status when handling Set MANA Purchase

### DIFF
--- a/src/modules/gateway/sagas.ts
+++ b/src/modules/gateway/sagas.ts
@@ -310,6 +310,7 @@ function* handleFiatGatewayPurchaseCompleted(
 function* handleSetManaPurchase(purchase: Purchase) {
   const finalStatuses = [
     PurchaseStatus.COMPLETE,
+    PurchaseStatus.REFUNDED,
     PurchaseStatus.FAILED,
     PurchaseStatus.CANCELLED
   ]


### PR DESCRIPTION
Closes #428 
Related to this [PR](https://github.com/decentraland/decentraland-dapps/pull/427)