### PR TITLE
fix: Update decentraland connect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "axios": "^0.21.1",
         "date-fns": "^1.29.0",
         "dcl-catalyst-client": "^14.0.9",
-        "decentraland-connect": "^3.5.0",
+        "decentraland-connect": "^3.7.0",
         "decentraland-crypto-fetch": "^1.0.3",
         "decentraland-transactions": "^1.44.0",
         "decentraland-ui": "^3.103.5",
@@ -5963,9 +5963,9 @@
       }
     },
     "node_modules/decentraland-connect": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.5.0.tgz",
-      "integrity": "sha512-oagcildoxZWSiI/QMjPx18L66sjwUrW6IvuLdpOXlvxfIabr86ddGDBo+tzh+eN0yA5GZQMEvLk1JU4VWLvBvg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.7.0.tgz",
+      "integrity": "sha512-TUZPxj3CmQKufLvWfLrbL79USykwSQD53qtMnHqIgq2g6/6Az2Ruxsm2rmkXyuX2WrusssHT9y/DQz8/Mtihcw==",
       "dependencies": {
         "@dcl/schemas": "^6.9.0",
         "@types/node": "^10.1.2",
@@ -24612,9 +24612,9 @@
       }
     },
     "decentraland-connect": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.5.0.tgz",
-      "integrity": "sha512-oagcildoxZWSiI/QMjPx18L66sjwUrW6IvuLdpOXlvxfIabr86ddGDBo+tzh+eN0yA5GZQMEvLk1JU4VWLvBvg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-3.7.0.tgz",
+      "integrity": "sha512-TUZPxj3CmQKufLvWfLrbL79USykwSQD53qtMnHqIgq2g6/6Az2Ruxsm2rmkXyuX2WrusssHT9y/DQz8/Mtihcw==",
       "requires": {
         "@dcl/schemas": "^6.9.0",
         "@types/node": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "axios": "^0.21.1",
     "date-fns": "^1.29.0",
     "dcl-catalyst-client": "^14.0.9",
-    "decentraland-connect": "^3.5.0",
+    "decentraland-connect": "^3.7.0",
     "decentraland-crypto-fetch": "^1.0.3",
     "decentraland-transactions": "^1.44.0",
     "decentraland-ui": "^3.103.5",


### PR DESCRIPTION
This PR updates the Decentraland Connect version to allow Fortmatic to work in Goerli by using our own RPC.