### PR TITLE
fix: make AuthorizationTranslationKeys optional recursively

### DIFF
--- a/src/containers/withAuthorizedAction/withAuthorizedAction.types.ts
+++ b/src/containers/withAuthorizedAction/withAuthorizedAction.types.ts
@@ -37,7 +37,15 @@ type AllowanceOptions = AuthorizeBaseOptions & {
 
 export type AuthorizeActionOptions = ApprovalOptions | AllowanceOptions
 
-export type AuthorizationTranslationKeys = Partial<
+type RecursivePartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? RecursivePartial<U>[]
+    : T[P] extends object
+    ? RecursivePartial<T[P]>
+    : T[P]
+}
+
+export type AuthorizationTranslationKeys = RecursivePartial<
   typeof en['@dapps']['authorization_modal']
 >
 


### PR DESCRIPTION
Make it possible to send partial values for translation even in nested objects:

Before this translationKeys object failed due to missing title

```
set_cap: {
   description: "key
}
```
considering this english translation

```
set_cap: {
  title: "Set cap title",
  description: "Set cap description"
}
```
