### PR TITLE
feat: add trace id to authorization flow events

### DIFF
--- a/src/containers/withAuthorizedAction/AuthorizationModal/AuthorizationModal.container.ts
+++ b/src/containers/withAuthorizedAction/AuthorizationModal/AuthorizationModal.container.ts
@@ -52,20 +52,22 @@ const mapDispatch = (
   dispatch: MapDispatch,
   ownProps: OwnProps
 ): MapDispatchProps => ({
-  onRevoke: () =>
+  onRevoke: (traceId: string) =>
     dispatch(
       authorizationFlowRequest(
         ownProps.authorization,
         AuthorizationAction.REVOKE,
-        ''
+        '',
+        traceId
       )
     ),
-  onGrant: () =>
+  onGrant: (traceId: string) =>
     dispatch(
       authorizationFlowRequest(
         ownProps.authorization,
         AuthorizationAction.GRANT,
-        ownProps.requiredAllowance?.toString() || ''
+        ownProps.requiredAllowance?.toString() || '',
+        traceId
       )
     ),
   onFetchAuthorizations: () =>

--- a/src/containers/withAuthorizedAction/AuthorizationModal/AuthorizationModal.spec.tsx
+++ b/src/containers/withAuthorizedAction/AuthorizationModal/AuthorizationModal.spec.tsx
@@ -547,7 +547,8 @@ describe('when clicking revoke authorization button', () => {
     expect(trackMock).toHaveBeenCalledWith(
       '[Authorization Flow] Authorize Revoke Click',
       {
-        action: AuthorizedAction.BUY
+        action: AuthorizedAction.BUY,
+        traceId: expect.any(String)
       }
     )
   })
@@ -604,7 +605,8 @@ describe('when clicking grant authorization button', () => {
     expect(trackMock).toHaveBeenCalledWith(
       '[Authorization Flow] Authorize Grant Click',
       {
-        action: AuthorizedAction.BUY
+        action: AuthorizedAction.BUY,
+        traceId: expect.any(String)
       }
     )
   })

--- a/src/containers/withAuthorizedAction/AuthorizationModal/AuthorizationModal.tsx
+++ b/src/containers/withAuthorizedAction/AuthorizationModal/AuthorizationModal.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import uuid from 'uuid'
 import { Network } from '@dcl/schemas'
 import {
   AuthorizationStep,
@@ -44,6 +45,7 @@ export function AuthorizationModal({
   onFetchAuthorizations
 }: Props) {
   const analytics = getAnalytics()
+  const [analyticsTraceId] = useState(uuid())
   const [currentStep, setCurrentStep] = useState(0)
   const [loading, setLoading] = useState<AuthorizationStepAction>()
   const [shouldReauthorize, setShouldReauthorize] = useState(false)
@@ -53,7 +55,8 @@ export function AuthorizationModal({
   useEffect(() => {
     analytics.track('[Authorization Flow] Modal Opened', {
       action,
-      requiredAllowance
+      requiredAllowance,
+      traceId: analyticsTraceId
     })
   }, [])
 
@@ -62,17 +65,19 @@ export function AuthorizationModal({
   }, [onFetchAuthorizations])
 
   const handleRevokeToken = useCallback(() => {
-    onRevoke()
+    onRevoke(analyticsTraceId)
     analytics.track('[Authorization Flow] Authorize Revoke Click', {
-      action
+      action,
+      traceId: analyticsTraceId
     })
     setLoading(AuthorizationStepAction.REVOKE)
   }, [onRevoke])
 
   const handleGrantToken = useCallback(() => {
-    onGrant()
+    onGrant(analyticsTraceId)
     analytics.track('[Authorization Flow] Authorize Grant Click', {
-      action
+      action,
+      traceId: analyticsTraceId
     })
     setLoading(AuthorizationStepAction.GRANT)
   }, [onGrant])
@@ -80,7 +85,8 @@ export function AuthorizationModal({
   const handleAuthorized = useCallback(() => {
     onAuthorized()
     analytics.track('[Authorization Flow] Confirm Transaction Click', {
-      action
+      action,
+      traceId: analyticsTraceId
     })
     setLoading(AuthorizationStepAction.CONFIRM)
   }, [onAuthorized])

--- a/src/containers/withAuthorizedAction/AuthorizationModal/AuthorizationModal.types.ts
+++ b/src/containers/withAuthorizedAction/AuthorizationModal/AuthorizationModal.types.ts
@@ -60,8 +60,8 @@ export type Props = {
   getConfirmationError?: (state: RootStateOrAny) => string | null
   onClose: () => void
   onAuthorized: () => void
-  onRevoke: () => ReturnType<typeof authorizationFlowRequest>
-  onGrant: () => ReturnType<typeof authorizationFlowRequest>
+  onRevoke: (traceId: string) => ReturnType<typeof authorizationFlowRequest>
+  onGrant: (traceId: string) => ReturnType<typeof authorizationFlowRequest>
   onFetchAuthorizations: () => ReturnType<typeof fetchAuthorizationsRequest>
 }
 

--- a/src/modules/authorization/actions.ts
+++ b/src/modules/authorization/actions.ts
@@ -108,12 +108,14 @@ export const AUTHORIZATION_FLOW_CLEAR = '[Clear] Authorization Flow'
 export const authorizationFlowRequest = (
   authorization: Authorization,
   authorizationAction: AuthorizationAction,
-  allowance?: string
+  allowance?: string,
+  traceId?: string
 ) =>
   action(AUTHORIZATION_FLOW_REQUEST, {
     authorization,
     authorizationAction,
-    allowance
+    allowance,
+    traceId
   })
 
 export const authorizationFlowSuccess = (authorization: Authorization) =>

--- a/src/modules/authorization/sagas.ts
+++ b/src/modules/authorization/sagas.ts
@@ -186,7 +186,12 @@ export function createAuthorizationSaga() {
   function* handleAuthorizationFlowRequest(
     action: AuthorizationFlowRequestAction
   ) {
-    const { authorizationAction, authorization, allowance } = action.payload
+    const {
+      authorizationAction,
+      authorization,
+      allowance,
+      traceId
+    } = action.payload
     const isRevoke = authorizationAction === AuthorizationAction.REVOKE
     const tokenRequest = isRevoke
       ? revokeTokenRequest(authorization)
@@ -215,7 +220,8 @@ export function createAuthorizationSaga() {
       analytics.track(
         `[Authorization Flow] ${
           isRevoke ? 'Revoke' : 'Grant'
-        } Transaction Approved in Wallet`
+        } Transaction Approved in Wallet`,
+        { traceId }
       )
       const txHash = getTransactionFromAction(
         success as RevokeTokenSuccessAction | GrantTokenSuccessAction


### PR DESCRIPTION
Add new parameter `traceId` to all authorization flow events so that then a funnel can be created to analyze user behavior