### PR TITLE
fix: Blankspace in translation

### DIFF
--- a/src/containers/AssetCard/utils.tsx
+++ b/src/containers/AssetCard/utils.tsx
@@ -51,7 +51,7 @@ export function getAssetListingsRangeInfoText(
 ) {
   return asset.minListingPrice && asset.maxListingPrice ? (
     <span className={'wrapBigText'}>
-      {asset.listings}
+      {asset.listings}&nbsp;
       {asset.listings === 1 ? translations.listing : translations.listings}
       :&nbsp;
       <span>


### PR DESCRIPTION
This PR adds a blankspace between the listings wording.