### PR TITLE
feat: add new page tracking hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,21 +849,18 @@ export function* rootSaga() {
 }
 ```
 
-This uses by default the `'@@router/LOCATION_CHANGE'` action type to track page changes. If you need to use a different action type, you can do the following:
+### Page tracking
+
+In order to track all page change you will need to use analytics `page` function. There is already an exported hook you can use the will be triggered everytime a location change in the app
+
+Note: It is important that this hook is triggered in any component inside the router provider.
 
 ```ts
-import { all } from 'redux-saga/effects'
-import { createAnalyticsSaga } from 'decentraland-dapps/dist/modules/analytics/sagas'
+import usePageTracking from 'decentraland-dapps/dist/hooks/usePageTracking'
 
-const analyticsSaga = createAnalyticsSaga({
-  LOCATION_CHANGE: 'custom action type'
-})
-
-export function* rootSaga() {
-  yield all([
-    analyticsSaga()
-    // your other sagas
-  ])
+function Routes() {
+  usePageTracking()
+  /// Route rendering
 }
 ```
 
@@ -1600,4 +1597,3 @@ export default class MyComponent extends React.PureComponent {
   }
 }
 ```
-

--- a/README.md
+++ b/README.md
@@ -851,7 +851,7 @@ export function* rootSaga() {
 
 ### Page tracking
 
-In order to track all page change you will need to use analytics `page` function. There is already an exported hook you can use the will be triggered everytime a location change in the app
+In order to track all page change you will need to use the analytics `page` function. There is already an exported hook you can use the will be triggered everytime a location change in the app
 
 Note: It is important that this hook is triggered in any component inside the router provider.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@types/ramda": "^0.27.44",
         "@types/react": "^17.0.17",
         "@types/react-redux": "^7.1.18",
+        "@types/react-router": "^5.1.20",
         "@types/redux-storage-engine-localstorage": "^1.1.1",
         "@types/uuid": "^9.0.5",
         "@types/ws": "^8.5.3",
@@ -4810,6 +4811,16 @@
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
       }
     },
     "node_modules/@types/redux-storage": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/ramda": "^0.27.44",
     "@types/react": "^17.0.17",
     "@types/react-redux": "^7.1.18",
+    "@types/react-router": "^5.1.20",
     "@types/redux-storage-engine-localstorage": "^1.1.1",
     "@types/uuid": "^9.0.5",
     "@types/ws": "^8.5.3",

--- a/src/hooks/usePageTracking.ts
+++ b/src/hooks/usePageTracking.ts
@@ -8,7 +8,6 @@ export function usePageTracking() {
   useEffect(() => {
     const analytics = getAnalytics()
     if (analytics) {
-      console.log({ location })
       analytics.page()
     }
   }, [location])

--- a/src/hooks/usePageTracking.ts
+++ b/src/hooks/usePageTracking.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router'
+import { getAnalytics } from '../modules/analytics'
+
+export function usePageTracking() {
+  const location = useLocation()
+
+  useEffect(() => {
+    const analytics = getAnalytics()
+    if (analytics) {
+      console.log({ location })
+      analytics.page()
+    }
+  }, [location])
+}

--- a/src/modules/analytics/sagas.ts
+++ b/src/modules/analytics/sagas.ts
@@ -1,4 +1,4 @@
-import { takeLatest, takeEvery, ForkEffect } from 'redux-saga/effects'
+import { takeLatest, ForkEffect } from 'redux-saga/effects'
 import { connection } from 'decentraland-connect'
 import { getAnalytics, trackConnectWallet } from './utils'
 import {
@@ -6,19 +6,9 @@ import {
   ConnectWalletSuccessAction
 } from '../wallet/actions'
 
-export type AnalyticsSagaOptions = {
-  LOCATION_CHANGE: string
-}
-
-export function createAnalyticsSaga(
-  options: AnalyticsSagaOptions = {
-    LOCATION_CHANGE: '@@router/LOCATION_CHANGE'
-  }
-) {
-  const { LOCATION_CHANGE } = options
+export function createAnalyticsSaga() {
   return function* analyticsSaga(): IterableIterator<ForkEffect> {
     yield takeLatest(CONNECT_WALLET_SUCCESS, handleConnectWalletSuccess)
-    yield takeEvery(LOCATION_CHANGE, handleLocationChange)
   }
 }
 
@@ -39,14 +29,5 @@ function handleConnectWalletSuccess(action: ConnectWalletSuccessAction) {
       providerType: wallet.providerType,
       walletName: connection.getWalletName()
     })
-  }
-}
-
-// Track pages
-function handleLocationChange() {
-  const analytics = getAnalytics()
-
-  if (analytics) {
-    analytics.page()
   }
 }


### PR DESCRIPTION
This PR is part of a series of PRs to stop using connected-react-router library. This PR starts sending the page event outside redux by using a hook when location changes

This is a breaking change as from now on we need to call `usePageTracking()` hooks in all our dapps