### PR TITLE
feat: Update decentraland-connect to version 7.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "axios": "^0.21.1",
         "date-fns": "^1.29.0",
         "dcl-catalyst-client": "^21.1.0",
-        "decentraland-connect": "^7.0.0",
+        "decentraland-connect": "^7.0.2",
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^2.6.0",
         "decentraland-ui": "^6.6.0",
@@ -7465,9 +7465,9 @@
       }
     },
     "node_modules/decentraland-connect": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-7.0.0.tgz",
-      "integrity": "sha512-jqLjAsHDpzvnN2FrUdNYJfDQBKCwMuWGf3YTV6Qk/YgEuVVv1KJ9YEAJYZk+ppJX4a2UnmBQN3ZZ50jIeHiCFw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-7.0.2.tgz",
+      "integrity": "sha512-5x03sLVJp5RRA3axYnSpwsoNWHo2wR31UHgPr0K6bUJRpVZV1DdNRUxLXvEJKQFEQ6I7LMLr6DD9tmBz2UGuhQ==",
       "dependencies": {
         "@dcl/schemas": "^11.4.0",
         "@dcl/single-sign-on-client": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "axios": "^0.21.1",
     "date-fns": "^1.29.0",
     "dcl-catalyst-client": "^21.1.0",
-    "decentraland-connect": "^7.0.0",
+    "decentraland-connect": "^7.0.2",
     "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-transactions": "^2.6.0",
     "decentraland-ui": "^6.6.0",


### PR DESCRIPTION
This PR upgrades the package `decentraland-connect` to version `7.0.2`