### PR TITLE
fix: Remove bytes conversion

### DIFF
--- a/src/lib/trades.spec.ts
+++ b/src/lib/trades.spec.ts
@@ -166,8 +166,8 @@ describe('when getting the trade signature', () => {
       domain = {
         name: offchainMarketplaceContract.name,
         version: offchainMarketplaceContract.version,
-        salt: SALT,
-        verifyingContract: offchainMarketplaceContract.address
+        verifyingContract: offchainMarketplaceContract.address,
+        salt: SALT
       }
 
       values = {
@@ -182,7 +182,7 @@ describe('when getting the trade signature', () => {
           externalChecks: trade.checks.externalChecks?.map(externalCheck => ({
             contractAddress: externalCheck.contractAddress,
             selector: externalCheck.selector,
-            value: externalCheck.value,
+            value: '0x',
             required: externalCheck.required
           }))
         },
@@ -190,13 +190,13 @@ describe('when getting the trade signature', () => {
           assetType: asset.assetType,
           contractAddress: asset.contractAddress,
           value: getValueForTradeAsset(asset),
-          extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra))
+          extra: '0x'
         })),
         received: trade.received.map(asset => ({
           assetType: asset.assetType,
           contractAddress: asset.contractAddress,
           value: getValueForTradeAsset(asset),
-          extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra)),
+          extra: '0x',
           beneficiary: asset.beneficiary
         }))
       }
@@ -274,14 +274,14 @@ describe('when getting the trade to accept', () => {
         assetType: asset.assetType,
         contractAddress: asset.contractAddress,
         value: getValueForTradeAsset(asset),
-        extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra)),
+        extra: '0x',
         beneficiary: beneficiaryAddress
       })),
       received: trade.received.map(asset => ({
         assetType: asset.assetType,
         contractAddress: asset.contractAddress,
         value: getValueForTradeAsset(asset),
-        extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra)),
+        extra: '0x',
         beneficiary: asset.beneficiary
       }))
     })

--- a/src/lib/trades.ts
+++ b/src/lib/trades.ts
@@ -97,9 +97,8 @@ export function generateTradeValues(trade: Omit<TradeCreation, 'signature'>) {
       externalChecks: trade.checks.externalChecks?.map(externalCheck => ({
         contractAddress: externalCheck.contractAddress,
         selector: externalCheck.selector,
-        value: ethers.utils.hexlify(
-          ethers.utils.toUtf8Bytes(externalCheck.value)
-        ),
+        // '0x' is the default value for value bytes (0 bytes)
+        value: externalCheck.value ? externalCheck.value : '0x',
         required: externalCheck.required
       }))
     },
@@ -107,13 +106,15 @@ export function generateTradeValues(trade: Omit<TradeCreation, 'signature'>) {
       assetType: asset.assetType,
       contractAddress: asset.contractAddress,
       value: getValueForTradeAsset(asset),
-      extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra))
+      // '0x' is the default value for value bytes (0 bytes)
+      extra: asset.extra ? asset.extra : '0x'
     })),
     received: trade.received.map(asset => ({
       assetType: asset.assetType,
       contractAddress: asset.contractAddress,
       value: getValueForTradeAsset(asset),
-      extra: ethers.utils.hexlify(ethers.utils.toUtf8Bytes(asset.extra)),
+      // '0x' is the default value for value bytes (0 bytes)
+      extra: asset.extra ? asset.extra : '0x',
       beneficiary: asset.beneficiary
     }))
   }
@@ -160,8 +161,8 @@ export async function getTradeSignature(
   const domain: TypedDataDomain = {
     name: marketplaceContract.name,
     version: marketplaceContract.version,
-    salt: SALT,
-    verifyingContract: marketplaceContract.address
+    verifyingContract: marketplaceContract.address,
+    salt: SALT
   }
 
   const signature = await signer._signTypedData(

--- a/src/lib/trades.ts
+++ b/src/lib/trades.ts
@@ -161,8 +161,8 @@ export async function getTradeSignature(
   const domain: TypedDataDomain = {
     name: marketplaceContract.name,
     version: marketplaceContract.version,
-    verifyingContract: marketplaceContract.address,
-    salt: SALT
+    salt: SALT,
+    verifyingContract: marketplaceContract.address
   }
 
   const signature = await signer._signTypedData(


### PR DESCRIPTION
This PR changes the way we're building the trade object to be signed to correctly set the parameters of byte values (extra and the external check values). The issue seems to have come from the usage of ethers.utils.hexlify ethers.utils.toUtf8Bytes to allow building the trade signature without failures when the byte parameters where set as empty strings, which the signature function would not recognize as empty byte arrays (the real type).
This PR replaces the usage of those functions in favor of setting the value '0x', the empty bytes value, when the bytes parameters is empty or the set value when it's set.