### PR TITLE
feat: Add feature variant selector

### DIFF
--- a/src/modules/features/selectors.spec.ts
+++ b/src/modules/features/selectors.spec.ts
@@ -3,6 +3,7 @@ import { getMockApplicationFeaturesRecord } from './actions.spec'
 import {
   getData,
   getError,
+  getFeatureVariant,
   getIsFeatureEnabled,
   getLoading,
   hasLoadedInitialFlags,
@@ -186,6 +187,127 @@ describe('when getting if a feature is enabled', () => {
         expect(
           getIsFeatureEnabled(state, ApplicationName.ACCOUNT, featureName)
         ).toEqual(false)
+      })
+    })
+  })
+})
+
+describe('when getting a feature variant', () => {
+  let data: ReturnType<typeof getMockApplicationFeaturesRecord>
+  let state: StateWithFeatures
+
+  beforeEach(() => {
+    data = getMockApplicationFeaturesRecord()
+    state = {
+      features: {
+        data,
+        error: null,
+        hasLoadedInitialFlags: false,
+        loading: []
+      }
+    }
+  })
+
+  describe('when the variant is defined in the environment', () => {
+    beforeEach(() => {
+      process.env.REACT_APP_FF_VARIANT_DAPPS_TEST_FEATURE = 'test-variant'
+    })
+
+    afterEach(() => {
+      delete process.env.REACT_APP_FF_VARIANT_DAPPS_TEST_FEATURE
+    })
+
+    it('should return a local variant with the environment value', () => {
+      expect(getFeatureVariant(state, ApplicationName.DAPPS, 'test-feature')).toEqual({
+        name: 'Local variant',
+        enabled: true,
+        payload: {
+          type: 'string',
+          value: 'test-variant'
+        }
+      })
+    })
+  })
+
+  describe('when the variant is not defined in the environment', () => {
+    describe('and the application features are not loaded', () => {
+      beforeEach(() => {
+        state = {
+          features: {
+            data: {},
+            error: null,
+            hasLoadedInitialFlags: false,
+            loading: []
+          }
+        }
+      })
+
+      it('should return null', () => {
+        expect(getFeatureVariant(state, ApplicationName.DAPPS, 'test-feature')).toBeNull()
+      })
+    })
+
+    describe('and the application features are loaded', () => {
+      describe('and the variant exists', () => {
+        beforeEach(() => {
+          state = {
+            features: {
+              data: {
+                [ApplicationName.DAPPS]: {
+                  name: ApplicationName.DAPPS,
+                  flags: {},
+                  variants: {
+                    'dapps-test-feature': {
+                      name: 'Remote variant',
+                      enabled: true,
+                      payload: {
+                        type: 'string',
+                        value: 'remote-variant'
+                      }
+                    }
+                  }
+                }
+              },
+              error: null,
+              hasLoadedInitialFlags: true,
+              loading: []
+            }
+          }
+        })
+
+        it('should return the variant from the store', () => {
+          expect(getFeatureVariant(state, ApplicationName.DAPPS, 'test-feature')).toEqual({
+            name: 'Remote variant',
+            enabled: true,
+            payload: {
+              type: 'string',
+              value: 'remote-variant'
+            }
+          })
+        })
+      })
+
+      describe('and the variant does not exist', () => {
+        beforeEach(() => {
+          state = {
+            features: {
+              data: {
+                [ApplicationName.DAPPS]: {
+                  name: ApplicationName.DAPPS,
+                  flags: {},
+                  variants: {}
+                }
+              },
+              error: null,
+              hasLoadedInitialFlags: true,
+              loading: []
+            }
+          }
+        })
+
+        it('should return null', () => {
+          expect(getFeatureVariant(state, ApplicationName.DAPPS, 'test-feature')).toBeNull()
+        })
       })
     })
   })


### PR DESCRIPTION
## Summary
Added a new `getFeatureVariant` selector function to retrieve feature variants from both environment variables and the Redux store.

## Changes
- Added `getFeatureVariant` selector function that:
  - First checks for variants defined in environment variables
  - Falls back to store-defined variants if no environment override exists
  - Returns `null` if no variant is found in either location

## Implementation Details
- Environment variants take precedence and are returned with a "Local variant" name
- Store variants are accessed using a composite key (`${app}-${feature}`)
- Added comprehensive test coverage for all scenarios:
  - Environment-defined variants
  - Store-defined variants
  - Non-existent variants
  - Cases where application features haven't been loaded yet

## Usage
```typescript
const variant = getFeatureVariant(state, ApplicationName.DAPPS, 'feature-name');
// Returns: { name: string, enabled: boolean, payload: { type: string, value: string } } | null