### PR TITLE
feat: Add Campaign module and Banner component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "23.24.9",
+  "version": "0.0.0-development",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "decentraland-dapps",
-      "version": "23.24.9",
+      "version": "0.0.0-development",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "decentraland-dapps",
-  "version": "0.0.0-development",
+  "version": "23.24.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "decentraland-dapps",
-      "version": "0.0.0-development",
+      "version": "23.24.9",
       "dependencies": {
         "@0xsequence/multicall": "^0.25.1",
         "@0xsequence/relayer": "^0.25.1",
         "@dcl/crypto": "^3.3.1",
-        "@dcl/schemas": "^15.1.2",
+        "@dcl/schemas": "^15.6.0",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^1.5.0",
         "@transak/transak-sdk": "^3.1.3",
@@ -26,7 +26,7 @@
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^2.18.0",
         "decentraland-ui": "^6.11.0",
-        "decentraland-ui2": "^0.8.7",
+        "decentraland-ui2": "^0.9.2",
         "ethers": "^5.6.8",
         "events": "^3.3.0",
         "flat": "^5.0.2",
@@ -39,8 +39,8 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "@swc/core": "^1.3.107",
-        "@swc/jest": "^0.2.31",
+        "@swc/core": "^1.10.7",
+        "@swc/jest": "^0.2.37",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^12.1.5",
@@ -1257,6 +1257,43 @@
         "protobufjs": "^6.8.8"
       }
     },
+    "node_modules/@contentful/rich-text-react-renderer": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-16.0.1.tgz",
+      "integrity": "sha512-7wZZBMgwbq5Udp2KebKCJoh9K+EPGlgRkudhXSp+OxtAIdBC6JUz3Oi9kXXKYKLeSg7iTBpkO1dd0/xFjHHKbg==",
+      "dependencies": {
+        "@contentful/rich-text-types": "^17.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-types": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-17.0.0.tgz",
+      "integrity": "sha512-x50t6sILzFHBdFpAo0foJRnH8fHWyidheWhAv3uwt9aOnNqTh893gxyoc3Q0RVEZxXfHpTi+O9gmakHcdlRdTA==",
+      "dependencies": {
+        "is-plain-obj": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@contentful/rich-text-types/node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@cosmjs/amino": {
       "version": "0.31.3",
       "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.3.tgz",
@@ -1830,9 +1867,9 @@
       }
     },
     "node_modules/@dcl/schemas": {
-      "version": "15.3.1",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-15.3.1.tgz",
-      "integrity": "sha512-VVh4qBgow9OsvI+CvJO9jJfZ/VwM5nBytk5T+8aRpxY8txhCebuzmr8NGLkWgaYAAd5vs5C61MVAbKlK+Y1Zow==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-15.6.0.tgz",
+      "integrity": "sha512-YBX9pqANci2bNmEpa+T48KYHg0dLz7gaNolwECjqXPWrwQZbNMlcz2vvU4+ZlOyMY2RwJxlz8NJSCyZfS23x1A==",
       "dependencies": {
         "ajv": "^8.11.0",
         "ajv-errors": "^3.0.0",
@@ -5174,14 +5211,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.3.107",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.107.tgz",
-      "integrity": "sha512-zKhqDyFcTsyLIYK1iEmavljZnf4CCor5pF52UzLAz4B6Nu/4GLU+2LQVAf+oRHjusG39PTPjd2AlRT3f3QWfsQ==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.7.tgz",
+      "integrity": "sha512-py91kjI1jV5D5W/Q+PurBdGsdU5TFbrzamP7zSCqLdMcHkKi3rQEM5jkQcZr0MXXSJTaayLxS3MWYTBIkzPDrg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@swc/counter": "^0.1.1",
-        "@swc/types": "^0.1.5"
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.17"
       },
       "engines": {
         "node": ">=10"
@@ -5191,19 +5228,19 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.3.107",
-        "@swc/core-darwin-x64": "1.3.107",
-        "@swc/core-linux-arm-gnueabihf": "1.3.107",
-        "@swc/core-linux-arm64-gnu": "1.3.107",
-        "@swc/core-linux-arm64-musl": "1.3.107",
-        "@swc/core-linux-x64-gnu": "1.3.107",
-        "@swc/core-linux-x64-musl": "1.3.107",
-        "@swc/core-win32-arm64-msvc": "1.3.107",
-        "@swc/core-win32-ia32-msvc": "1.3.107",
-        "@swc/core-win32-x64-msvc": "1.3.107"
+        "@swc/core-darwin-arm64": "1.10.7",
+        "@swc/core-darwin-x64": "1.10.7",
+        "@swc/core-linux-arm-gnueabihf": "1.10.7",
+        "@swc/core-linux-arm64-gnu": "1.10.7",
+        "@swc/core-linux-arm64-musl": "1.10.7",
+        "@swc/core-linux-x64-gnu": "1.10.7",
+        "@swc/core-linux-x64-musl": "1.10.7",
+        "@swc/core-win32-arm64-msvc": "1.10.7",
+        "@swc/core-win32-ia32-msvc": "1.10.7",
+        "@swc/core-win32-x64-msvc": "1.10.7"
       },
       "peerDependencies": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": "*"
       },
       "peerDependenciesMeta": {
         "@swc/helpers": {
@@ -5211,10 +5248,26 @@
         }
       }
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.7.tgz",
+      "integrity": "sha512-SI0OFg987P6hcyT0Dbng3YRISPS9uhLX1dzW4qRrfqQdb0i75lPJ2YWe9CN47HBazrIA5COuTzrD2Dc0TcVsSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.3.107",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.107.tgz",
-      "integrity": "sha512-hwiLJ2ulNkBGAh1m1eTfeY1417OAYbRGcb/iGsJ+LuVLvKAhU/itzsl535CvcwAlt2LayeCFfcI8gdeOLeZa9A==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.7.tgz",
+      "integrity": "sha512-RFIAmWVicD/l3RzxgHW0R/G1ya/6nyMspE2cAeDcTbjHi0I5qgdhBWd6ieXOaqwEwiCd0Mot1g2VZrLGoBLsjQ==",
       "cpu": [
         "x64"
       ],
@@ -5227,19 +5280,148 @@
         "node": ">=10"
       }
     },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.7.tgz",
+      "integrity": "sha512-QP8vz7yELWfop5mM5foN6KkLylVO7ZUgWSF2cA0owwIaziactB2hCPZY5QU690coJouk9KmdFsPWDnaCFUP8tg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.7.tgz",
+      "integrity": "sha512-NgUDBGQcOeLNR+EOpmUvSDIP/F7i/OVOKxst4wOvT5FTxhnkWrW+StJGKj+DcUVSK5eWOYboSXr1y+Hlywwokw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.7.tgz",
+      "integrity": "sha512-gp5Un3EbeSThBIh6oac5ZArV/CsSmTKj5jNuuUAuEsML3VF9vqPO+25VuxCvsRf/z3py+xOWRaN2HY/rjMeZog==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.7.tgz",
+      "integrity": "sha512-k/OxLLMl/edYqbZyUNg6/bqEHTXJT15l9WGqsl/2QaIGwWGvles8YjruQYQ9d4h/thSXLT9gd8bExU2D0N+bUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.7.tgz",
+      "integrity": "sha512-XeDoURdWt/ybYmXLCEE8aSiTOzEn0o3Dx5l9hgt0IZEmTts7HgHHVeRgzGXbR4yDo0MfRuX5nE1dYpTmCz0uyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.7.tgz",
+      "integrity": "sha512-nYAbi/uLS+CU0wFtBx8TquJw2uIMKBnl04LBmiVoFrsIhqSl+0MklaA9FVMGA35NcxSJfcm92Prl2W2LfSnTqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.7.tgz",
+      "integrity": "sha512-+aGAbsDsIxeLxw0IzyQLtvtAcI1ctlXVvVcXZMNXIXtTURM876yNrufRo4ngoXB3jnb1MLjIIjgXfFs/eZTUSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.7.tgz",
+      "integrity": "sha512-TBf4clpDBjF/UUnkKrT0/th76/zwvudk5wwobiTFqDywMApHip5O0VpBgZ+4raY2TM8k5+ujoy7bfHb22zu17Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/counter": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.2.tgz",
-      "integrity": "sha512-9F4ys4C74eSTEUNndnER3VJ15oru2NumfQxS8geE+f3eB5xvfxpWyqE5XlVnxb/R14uoXi6SLbBwwiDSkv+XEw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "dev": true
     },
     "node_modules/@swc/jest": {
-      "version": "0.2.31",
-      "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.31.tgz",
-      "integrity": "sha512-Gh0Ste380O8KUY1IqsKr+aOvqqs2Loa+WcWWVNwl+lhXqOWK1iTFAP1K0IDfLqAuFP68+D/PxcpBJn21e6Quvw==",
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.37.tgz",
+      "integrity": "sha512-CR2BHhmXKGxTiFr21DYPRHQunLkX3mNIFGFkxBGji6r9uyIR5zftTOVYj1e0sFNMV2H7mf/+vpaglqaryBtqfQ==",
       "dev": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
+        "@swc/counter": "^0.1.3",
         "jsonc-parser": "^3.2.0"
       },
       "engines": {
@@ -5250,10 +5432,13 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.5.tgz",
-      "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
-      "dev": true
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
+      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
+      "dev": true,
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
     },
     "node_modules/@testing-library/dom": {
       "version": "8.20.0",
@@ -8616,11 +8801,12 @@
       }
     },
     "node_modules/decentraland-ui2": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-0.8.7.tgz",
-      "integrity": "sha512-MT3Ife/jG1sn9OrSbdSyMGd+XTcLqGP2xfu7FcVAqfGk9JLbRP+QUb5+4LInDApGqMq+v374K+s35vgsDwLB+A==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-0.9.2.tgz",
+      "integrity": "sha512-5mCgR6wQ9KEcbb4SAMhNe5lx3DABH9sewKxD1Qy3+Ap3kMM7mH5iuDVHBvHnfBtHdD5iHNFzdbIUdGbprN1XJA==",
       "dependencies": {
-        "@dcl/schemas": "^13.9.0",
+        "@contentful/rich-text-react-renderer": "^16.0.1",
+        "@dcl/schemas": "^15.6.0",
         "@dcl/ui-env": "^1.5.1",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
@@ -8633,17 +8819,6 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-tile-map": "^0.4.1"
-      }
-    },
-    "node_modules/decentraland-ui2/node_modules/@dcl/schemas": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/@dcl/schemas/-/schemas-13.13.0.tgz",
-      "integrity": "sha512-UY7YY7pn0TxSrinO5nayBushF5Sf1jcBpbsLdw4wWOq7urhzSQZGjbAomgJZ7UfOMi1C7DD2XaTZ89BCp/4Z9Q==",
-      "dependencies": {
-        "ajv": "^8.11.0",
-        "ajv-errors": "^3.0.0",
-        "ajv-keywords": "^5.1.0",
-        "mitt": "^3.0.1"
       }
     },
     "node_modules/decentraland-ui2/node_modules/date-fns": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "23.24.9",
+  "version": "0.0.0-development",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "0.0.0-development",
+  "version": "23.24.9",
   "type": "module",
   "main": "dist/index.js",
   "files": [
@@ -10,7 +10,7 @@
     "@0xsequence/multicall": "^0.25.1",
     "@0xsequence/relayer": "^0.25.1",
     "@dcl/crypto": "^3.3.1",
-    "@dcl/schemas": "^15.1.2",
+    "@dcl/schemas": "^15.6.0",
     "@dcl/single-sign-on-client": "^0.1.0",
     "@dcl/ui-env": "^1.5.0",
     "@transak/transak-sdk": "^3.1.3",
@@ -25,7 +25,7 @@
     "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-transactions": "^2.18.0",
     "decentraland-ui": "^6.11.0",
-    "decentraland-ui2": "^0.8.7",
+    "decentraland-ui2": "^0.9.2",
     "ethers": "^5.6.8",
     "events": "^3.3.0",
     "flat": "^5.0.2",
@@ -46,8 +46,8 @@
     "commitmsg": "validate-commit-msg"
   },
   "devDependencies": {
-    "@swc/core": "^1.3.107",
-    "@swc/jest": "^0.2.31",
+    "@swc/core": "^1.10.7",
+    "@swc/jest": "^0.2.37",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^12.1.5",

--- a/src/containers/Banner/Banner.container.ts
+++ b/src/containers/Banner/Banner.container.ts
@@ -1,0 +1,18 @@
+import { connect } from 'react-redux'
+import { Banner } from 'decentraland-ui2'
+import {
+  getBanner,
+  getBannerAssets,
+  getError,
+  isLoading
+} from '../../modules/campaign'
+import { MapStateProps, OwnProps } from './Banner.types'
+
+const mapState = (state: any, ownProps: OwnProps): MapStateProps => ({
+  fields: getBanner(state, ownProps.id) ?? null,
+  assets: getBannerAssets(state, ownProps.id),
+  isLoading: isLoading(state),
+  error: getError(state)
+})
+
+export default connect<MapStateProps, {}, OwnProps>(mapState)(Banner)

--- a/src/containers/Banner/Banner.types.ts
+++ b/src/containers/Banner/Banner.types.ts
@@ -1,0 +1,6 @@
+import { BannerProps as UIBannerProps } from "decentraland-ui2"
+
+export type BannerProps = UIBannerProps & { id: string }
+export type OwnProps = Pick<BannerProps, 'id'>
+export type MapStateProps = Pick<BannerProps, 'fields' | 'assets' | 'isLoading' | 'error'>
+

--- a/src/containers/Banner/index.ts
+++ b/src/containers/Banner/index.ts
@@ -1,0 +1,4 @@
+import Banner from './Banner.container'
+
+export { Banner }
+export * from './Banner.types'

--- a/src/modules/campaign/ContentfulClient.spec.ts
+++ b/src/modules/campaign/ContentfulClient.spec.ts
@@ -1,0 +1,87 @@
+import { ContentfulResponse } from '@dcl/schemas'
+import { ContentfulClient } from './ContentfulClient'
+import { mockHomepageBannerEntry } from '../../tests/contentfulMocks'
+
+describe('ContentfulClient', () => {
+  let client: ContentfulClient
+
+  beforeEach(() => {
+    client = new ContentfulClient()
+  })
+
+  describe('fetchEntry', () => {
+    const mockSpace = 'test-space'
+    const mockEnvironment = 'test-env'
+    const mockId = 'test-id'
+    const mockContentType = 'test-content-type'
+    const mockToken = 'test-token'
+
+    describe('when the request is successful', () => {
+      let mockResponse: ContentfulResponse<any>
+      beforeEach(() => {
+        mockResponse = {
+          items: [{ ...mockHomepageBannerEntry }],
+          includes: {
+            Asset: [],
+            Entry: []
+          }
+        }
+        global.fetch = jest.fn().mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve(mockResponse)
+        })
+      })
+
+      it('should have fetched the entry with the given parameters', async () => {
+        await client.fetchEntry(
+          mockSpace,
+          mockEnvironment,
+          mockId,
+          mockContentType,
+          mockToken
+        )
+
+        expect(fetch).toHaveBeenCalledWith(
+          `https://cdn.contentful.com/spaces/${mockSpace}/environments/${mockEnvironment}/entries/?sys.id=${mockId}&content_type=${mockContentType}&locale=*`,
+          {
+            headers: {
+              Authorization: `Bearer ${mockToken}`
+            }
+          }
+        )
+      })
+
+      it('should return the parsed response', async () => {
+        const result = await client.fetchEntry(
+          mockSpace,
+          mockEnvironment,
+          mockId,
+          mockContentType,
+          mockToken
+        )
+
+        expect(result).toEqual(mockResponse)
+      })
+    })
+
+    describe('when the request fails', () => {
+      beforeEach(() => {
+        global.fetch = jest.fn().mockResolvedValue({
+          ok: false
+        })
+      })
+
+      it('should throw an error', async () => {
+        await expect(
+          client.fetchEntry(
+            mockSpace,
+            mockEnvironment,
+            mockId,
+            mockContentType,
+            mockToken
+          )
+        ).rejects.toThrow('Failed to fetch entity data')
+      })
+    })
+  })
+})

--- a/src/modules/campaign/ContentfulClient.ts
+++ b/src/modules/campaign/ContentfulClient.ts
@@ -1,0 +1,42 @@
+import {
+  ContentfulResponse,
+  LocalizedField,
+  LocalizedFieldType
+} from '@dcl/schemas'
+import { BaseClient } from '../../lib'
+
+export class ContentfulClient extends BaseClient {
+  constructor() {
+    super('https://cdn.contentful.com')
+  }
+
+  async fetchEntry<
+    T extends Record<string, LocalizedField<LocalizedFieldType>>
+  >(
+    space: string,
+    environment: string,
+    id: string,
+    contentType: string,
+    token: string
+  ): Promise<ContentfulResponse<T>> {
+    const response = await this.rawFetch(
+      `/spaces/${space}/environments/${environment}/entries/?` +
+        new URLSearchParams({
+          'sys.id': id,
+          content_type: contentType,
+          locale: '*'
+        }),
+      {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      }
+    )
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch entity data')
+    }
+
+    return response.json()
+  }
+}

--- a/src/modules/campaign/actions.spec.ts
+++ b/src/modules/campaign/actions.spec.ts
@@ -1,0 +1,100 @@
+import { ContentfulAsset, BannerFields } from '@dcl/schemas'
+import {
+  marketplaceHomepageBannerAssets,
+  mockHomepageBannerEntry
+} from '../../tests/contentfulMocks'
+import {
+  fetchCampaignRequest,
+  fetchCampaignSuccess,
+  fetchCampaignFailure,
+  FETCH_CAMPAIGN_REQUEST,
+  FETCH_CAMPAIGN_SUCCESS,
+  FETCH_CAMPAIGN_FAILURE
+} from './actions'
+
+describe('Campaign actions', () => {
+  describe('when fetching campaign data', () => {
+    describe('when calling the request action creator', () => {
+      let action: ReturnType<typeof fetchCampaignRequest>
+      let expectedAction: ReturnType<typeof fetchCampaignRequest>
+
+      beforeEach(() => {
+        action = fetchCampaignRequest()
+        expectedAction = {
+          type: FETCH_CAMPAIGN_REQUEST
+        }
+      })
+
+      it('should return the request action', () => {
+        expect(action).toEqual(expectedAction)
+      })
+    })
+
+    describe('when calling the success action creator', () => {
+      let action: ReturnType<typeof fetchCampaignSuccess>
+      let expectedAction: ReturnType<typeof fetchCampaignSuccess>
+
+      beforeEach(() => {
+        const name = {
+          'en-US': 'Test Campaign'
+        }
+        const tabName = {
+          'en-US': 'Test Tab'
+        }
+        const mainTag = 'main-tag'
+        const additionalTags = ['tag1', 'tag2']
+        const banners: Record<string, BannerFields> = {
+          [mockHomepageBannerEntry.sys.id]: mockHomepageBannerEntry.fields
+        }
+        const assets: Record<string, ContentfulAsset> = {
+          [marketplaceHomepageBannerAssets[0].sys.id]:
+            marketplaceHomepageBannerAssets[0]
+        }
+        action = fetchCampaignSuccess(
+          banners,
+          assets,
+          name,
+          tabName,
+          mainTag,
+          additionalTags
+        )
+        expectedAction = {
+          type: FETCH_CAMPAIGN_SUCCESS,
+          payload: {
+            name,
+            tabName,
+            mainTag,
+            additionalTags,
+            banners,
+            assets
+          }
+        }
+      })
+
+      it('should return the success action with the campaign data', () => {
+        expect(action).toEqual(expectedAction)
+      })
+    })
+
+    describe('when calling the failure action creator', () => {
+      let action: ReturnType<typeof fetchCampaignFailure>
+      let expectedAction: ReturnType<typeof fetchCampaignFailure>
+      let error: string
+
+      beforeEach(() => {
+        error = 'Failed to fetch campaign'
+        action = fetchCampaignFailure(error)
+        expectedAction = {
+          type: FETCH_CAMPAIGN_FAILURE,
+          payload: {
+            error
+          }
+        }
+      })
+
+      it('should return the failure action with the error', () => {
+        expect(action).toEqual(expectedAction)
+      })
+    })
+  })
+})

--- a/src/modules/campaign/actions.ts
+++ b/src/modules/campaign/actions.ts
@@ -1,16 +1,14 @@
 import { action } from 'typesafe-actions'
-import type { IBannerFields } from 'decentraland-ui2'
-import { LocalizedField, ContentfulAsset } from './types'
+import { BannerFields, ContentfulAsset, LocalizedField } from '@dcl/schemas'
 
 export const FETCH_CAMPAIGN_REQUEST = '[Request] Fetch Campaign'
 export const FETCH_CAMPAIGN_SUCCESS = '[Success] Fetch Campaign'
 export const FETCH_CAMPAIGN_FAILURE = '[Failure] Fetch Campaign'
 
-export const fetchCampaignRequest = () =>
-  action(FETCH_CAMPAIGN_REQUEST)
+export const fetchCampaignRequest = () => action(FETCH_CAMPAIGN_REQUEST)
 
 export const fetchCampaignSuccess = (
-  banners: Record<string, IBannerFields>,
+  banners: Record<string, BannerFields>,
   assets: Record<string, ContentfulAsset>,
   name?: LocalizedField<string>,
   tabName?: LocalizedField<string>,
@@ -28,7 +26,6 @@ export const fetchCampaignSuccess = (
 
 export const fetchCampaignFailure = (error: string) =>
   action(FETCH_CAMPAIGN_FAILURE, { error })
-
 
 export type FetchCampaignRequestAction = ReturnType<typeof fetchCampaignRequest>
 export type FetchCampaignSuccessAction = ReturnType<typeof fetchCampaignSuccess>

--- a/src/modules/campaign/actions.ts
+++ b/src/modules/campaign/actions.ts
@@ -1,0 +1,35 @@
+import { action } from 'typesafe-actions'
+import type { IBannerFields } from 'decentraland-ui2'
+import { LocalizedField, ContentfulAsset } from './types'
+
+export const FETCH_CAMPAIGN_REQUEST = '[Request] Fetch Campaign'
+export const FETCH_CAMPAIGN_SUCCESS = '[Success] Fetch Campaign'
+export const FETCH_CAMPAIGN_FAILURE = '[Failure] Fetch Campaign'
+
+export const fetchCampaignRequest = () =>
+  action(FETCH_CAMPAIGN_REQUEST)
+
+export const fetchCampaignSuccess = (
+  banners: Record<string, IBannerFields>,
+  assets: Record<string, ContentfulAsset>,
+  name?: LocalizedField<string>,
+  tabName?: LocalizedField<string>,
+  mainTag?: string,
+  additionalTags?: string[]
+) =>
+  action(FETCH_CAMPAIGN_SUCCESS, {
+    name,
+    tabName,
+    mainTag,
+    additionalTags,
+    banners,
+    assets
+  })
+
+export const fetchCampaignFailure = (error: string) =>
+  action(FETCH_CAMPAIGN_FAILURE, { error })
+
+
+export type FetchCampaignRequestAction = ReturnType<typeof fetchCampaignRequest>
+export type FetchCampaignSuccessAction = ReturnType<typeof fetchCampaignSuccess>
+export type FetchCampaignFailureAction = ReturnType<typeof fetchCampaignFailure>

--- a/src/modules/campaign/index.ts
+++ b/src/modules/campaign/index.ts
@@ -1,0 +1,6 @@
+export * from './actions'
+export * from './reducer'
+export * from './sagas'
+export * from './selectors'
+export * from './types'
+export * from './ContentfulClient'

--- a/src/modules/campaign/reducer.spec.ts
+++ b/src/modules/campaign/reducer.spec.ts
@@ -1,0 +1,118 @@
+import { loadingReducer } from '../loading/reducer'
+import {
+  fetchCampaignRequest,
+  fetchCampaignSuccess,
+  fetchCampaignFailure
+} from './actions'
+import { campaignReducer } from './reducer'
+import { CampaignState } from './types'
+
+let initialState: CampaignState
+
+describe('Campaign reducer', () => {
+  beforeEach(() => {
+    initialState = {
+      data: null,
+      loading: [],
+      error: null
+    }
+  })
+
+  describe('when handling the fetch campaign request action', () => {
+    let state: CampaignState
+    let action: ReturnType<typeof fetchCampaignRequest>
+
+    beforeEach(() => {
+      action = fetchCampaignRequest()
+      const stateWithError: CampaignState = {
+        ...initialState,
+        error: 'Some previous error'
+      }
+      state = campaignReducer(stateWithError, action)
+    })
+
+    it('should add the action to the loading state and clear the error', () => {
+      expect(state).toEqual({
+        data: null,
+        loading: loadingReducer([], action),
+        error: null
+      })
+    })
+  })
+
+  describe('when handling the fetch campaign success action', () => {
+    let state: CampaignState
+    let requestAction: ReturnType<typeof fetchCampaignRequest>
+    let successAction: ReturnType<typeof fetchCampaignSuccess>
+    let campaignData: CampaignState['data']
+
+    beforeEach(() => {
+      requestAction = fetchCampaignRequest()
+      campaignData = {
+        name: { 'en-US': 'Test Name' },
+        tabName: { 'en-US': 'Test Tab' },
+        mainTag: 'main-tag',
+        additionalTags: ['tag1', 'tag2'],
+        banners: {},
+        assets: {}
+      }
+
+      successAction = fetchCampaignSuccess(
+        campaignData.banners,
+        campaignData.assets,
+        campaignData.name,
+        campaignData.tabName,
+        campaignData.mainTag,
+        campaignData.additionalTags
+      )
+
+      const loadingState = campaignReducer(initialState, requestAction)
+      state = campaignReducer(loadingState, successAction)
+    })
+
+    it('should update the data and remove the loading state', () => {
+      expect(state).toEqual({
+        data: campaignData,
+        loading: loadingReducer([requestAction], successAction),
+        error: null
+      })
+    })
+  })
+
+  describe('when handling the fetch campaign failure action', () => {
+    let state: CampaignState
+    let requestAction: ReturnType<typeof fetchCampaignRequest>
+    let failureAction: ReturnType<typeof fetchCampaignFailure>
+    let errorMessage: string
+
+    beforeEach(() => {
+      requestAction = fetchCampaignRequest()
+      errorMessage = 'Failed to fetch campaign'
+      failureAction = fetchCampaignFailure(errorMessage)
+
+      const loadingState = campaignReducer(initialState, requestAction)
+      state = campaignReducer(loadingState, failureAction)
+    })
+
+    it('should set the error and remove the loading state', () => {
+      expect(state).toEqual({
+        data: null,
+        loading: loadingReducer([requestAction], failureAction),
+        error: errorMessage
+      })
+    })
+  })
+
+  describe('when handling an unknown action', () => {
+    let state: CampaignState
+
+    beforeEach(() => {
+      const action = { type: 'UNKNOWN_ACTION' }
+      state = campaignReducer(initialState, action as any)
+    })
+
+    it('should return the same state', () => {
+      expect(state).toEqual(initialState)
+    })
+  })
+})

--- a/src/modules/campaign/reducer.ts
+++ b/src/modules/campaign/reducer.ts
@@ -1,0 +1,45 @@
+import { loadingReducer } from '../loading/reducer'
+import { CampaignState, CampaignAction } from './types'
+import {
+  FETCH_CAMPAIGN_REQUEST,
+  FETCH_CAMPAIGN_SUCCESS,
+  FETCH_CAMPAIGN_FAILURE
+} from './actions'
+
+const INITIAL_STATE: CampaignState = {
+  data: null,
+  loading: [],
+  error: null
+}
+
+export function campaignReducer(
+  state = INITIAL_STATE,
+  action: CampaignAction
+): CampaignState {
+  switch (action.type) {
+    case FETCH_CAMPAIGN_REQUEST: {
+      return {
+        ...state,
+        loading: loadingReducer(state.loading, action),
+        error: null
+      }
+    }
+    case FETCH_CAMPAIGN_SUCCESS: {
+      return {
+        ...state,
+        loading: loadingReducer(state.loading, action),
+        data: action.payload,
+        error: null
+      }
+    }
+    case FETCH_CAMPAIGN_FAILURE: {
+      return {
+        ...state,
+        loading: loadingReducer(state.loading, action),
+        error: action.payload.error
+      }
+    }
+    default:
+      return state
+  }
+}

--- a/src/modules/campaign/sagas.spec.ts
+++ b/src/modules/campaign/sagas.spec.ts
@@ -1,0 +1,141 @@
+import { expectSaga } from 'redux-saga-test-plan'
+import * as matchers from 'redux-saga-test-plan/matchers'
+import { throwError } from 'redux-saga-test-plan/providers'
+import { ContentfulResponse, MarketingAdminFields } from '@dcl/schemas'
+import {
+  mockAdminEntry,
+  marketplaceHomepageBannerAssets,
+  mockCampaignEntry,
+  mockHomepageBannerEntry
+} from '../../tests/contentfulMocks'
+import { ContentfulClient } from './ContentfulClient'
+import { campaignSagas } from './sagas'
+import {
+  fetchCampaignRequest,
+  fetchCampaignSuccess,
+  fetchCampaignFailure
+} from './actions'
+
+describe('when handling the fetch campaign request', () => {
+  let mockConfig: {
+    space: string
+    environment: string
+    id: string
+    token: string
+  }
+  let mockClient: ContentfulClient
+  let mockResponse: ContentfulResponse<MarketingAdminFields>
+
+  beforeEach(() => {
+    mockConfig = {
+      space: 'space-id',
+      environment: 'environment-id',
+      id: 'entry-id',
+      token: 'access-token'
+    }
+    mockClient = new ContentfulClient()
+  })
+
+  describe('when the request is successful', () => {
+    beforeEach(() => {
+      mockResponse = {
+        items: [{ ...mockAdminEntry }],
+        includes: {
+          Asset: [...marketplaceHomepageBannerAssets],
+          Entry: [{ ...mockHomepageBannerEntry }, { ...mockCampaignEntry }]
+        }
+      }
+    })
+
+    it('should put fetch campaign success with the transformed campaign data', () => {
+      return expectSaga(campaignSagas, mockClient, mockConfig)
+        .provide([
+          [
+            matchers.call(
+              [mockClient, 'fetchEntry'],
+              mockConfig.space,
+              mockConfig.environment,
+              mockConfig.id,
+              'admin',
+              mockConfig.token
+            ),
+            mockResponse
+          ]
+        ])
+        .put(
+          fetchCampaignSuccess(
+            {
+              marketplaceHomepageBanner: { ...mockHomepageBannerEntry.fields }
+            },
+            {
+              [marketplaceHomepageBannerAssets[0].sys.id]:
+                marketplaceHomepageBannerAssets[0],
+              [marketplaceHomepageBannerAssets[1].sys.id]:
+                marketplaceHomepageBannerAssets[1],
+              [marketplaceHomepageBannerAssets[2].sys.id]:
+                marketplaceHomepageBannerAssets[2]
+            },
+            mockCampaignEntry.fields.name,
+            mockCampaignEntry.fields.marketplaceTabName,
+            mockCampaignEntry.fields.mainTag?.['en-US'],
+            mockCampaignEntry.fields.additionalTags?.['en-US']
+          )
+        )
+        .dispatch(fetchCampaignRequest())
+        .run()
+    })
+  })
+
+  describe('when the request fails', () => {
+    it('should put fetch campaign failure with the error message', () => {
+      const error = new Error('Network error')
+
+      return expectSaga(campaignSagas, mockClient, mockConfig)
+        .provide([
+          [
+            matchers.call(
+              [mockClient, 'fetchEntry'],
+              mockConfig.space,
+              mockConfig.environment,
+              mockConfig.id,
+              'admin',
+              mockConfig.token
+            ),
+            throwError(error)
+          ]
+        ])
+        .put(fetchCampaignFailure('Network error'))
+        .dispatch(fetchCampaignRequest())
+        .run()
+    })
+  })
+
+  describe('when the response contains no items', () => {
+    beforeEach(() => {
+      mockResponse = {
+        items: [],
+        includes: {}
+      }
+    })
+
+    it('should put fetch campaign failure with an error message', () => {
+      return expectSaga(campaignSagas, mockClient, mockConfig)
+        .provide([
+          [
+            matchers.call(
+              [mockClient, 'fetchEntry'],
+              mockConfig.space,
+              mockConfig.environment,
+              mockConfig.id,
+              'admin',
+              mockConfig.token
+            ),
+            mockResponse
+          ]
+        ])
+        .put(fetchCampaignFailure('Failed to fetch campaign data'))
+        .dispatch(fetchCampaignRequest())
+        .run()
+    })
+  })
+})

--- a/src/modules/campaign/sagas.ts
+++ b/src/modules/campaign/sagas.ts
@@ -1,0 +1,114 @@
+import { call, put, takeEvery } from 'redux-saga/effects'
+import {
+  BannerFields,
+  CampaignFields,
+  ContentfulAsset,
+  ContentfulEntry,
+  ContentfulResponse,
+  ContentfulLocale,
+  LocalizedField,
+  LocalizedFields,
+  MarketingAdminFields,
+  SysLink,
+  isSysLink
+} from '@dcl/schemas'
+import { isErrorWithMessage } from '../../lib'
+import { FETCH_CAMPAIGN_REQUEST, FetchCampaignRequestAction } from './actions'
+import { fetchCampaignSuccess, fetchCampaignFailure } from './actions'
+import { ContentfulClient } from './ContentfulClient'
+
+const ADMIN_CONTENT_TYPE = 'admin'
+const BANNER_CONTENT_TYPE = 'banner'
+const MARKETING_CAMPAIGN_CONTENT_TYPE = 'marketingCampaign'
+
+export function* campaignSagas(
+  client: ContentfulClient,
+  config: {
+    space: string
+    environment: string
+    id: string
+    token: string
+  }
+) {
+  yield takeEvery(FETCH_CAMPAIGN_REQUEST, handleFetchCampaignRequest)
+
+  function* handleFetchCampaignRequest(_: FetchCampaignRequestAction) {
+    try {
+      const { items, includes } = (yield call(
+        [client, 'fetchEntry'],
+        config.space,
+        config.environment,
+        config.id,
+        ADMIN_CONTENT_TYPE,
+        config.token
+      )) as ContentfulResponse<MarketingAdminFields>
+
+      if (!items || (items && items.length === 0)) {
+        throw new Error('Failed to fetch campaign data')
+      }
+
+      const assets = (includes.Asset ?? []).reduce((acc, asset) => {
+        acc[asset.sys.id] = asset
+        return acc
+      }, {} as Record<string, ContentfulAsset>)
+
+      const entries = (includes.Entry ?? []).reduce((acc, entry) => {
+        acc[entry.sys.id] = entry
+        return acc
+      }, {} as Record<string, ContentfulEntry<LocalizedFields>>)
+
+      const banners = Object.entries(items[0].fields).reduce(
+        (acc, [key, value]) => {
+          const fieldOnLocale = value[ContentfulLocale.enUS]
+          if (isSysLink(fieldOnLocale)) {
+            const linkedEntryId = fieldOnLocale.sys.id
+            const bannerEntry = entries[linkedEntryId]
+            if (
+              bannerEntry &&
+              bannerEntry.sys.contentType.sys.id === BANNER_CONTENT_TYPE
+            ) {
+              acc[key] = (bannerEntry.fields as unknown) as BannerFields
+            }
+          }
+          return acc
+        },
+        {} as Record<string, BannerFields>
+      )
+
+      const campaignField = Object.values(items[0].fields).find(field => {
+        const fieldOnLocale = field[ContentfulLocale.enUS]
+        if (isSysLink(fieldOnLocale)) {
+          const entry = entries[fieldOnLocale.sys.id]
+          if (
+            entry.sys.contentType.sys.id === MARKETING_CAMPAIGN_CONTENT_TYPE
+          ) {
+            return entry.fields as CampaignFields
+          }
+        }
+        return false
+      }) as LocalizedField<SysLink<'Entry'>> | undefined
+
+      const campaignFields = campaignField?.[ContentfulLocale.enUS].sys.id
+        ? (entries[campaignField?.[ContentfulLocale.enUS].sys.id]
+            ?.fields as CampaignFields)
+        : undefined
+
+      yield put(
+        fetchCampaignSuccess(
+          banners,
+          assets,
+          campaignFields?.name,
+          campaignFields?.marketplaceTabName,
+          campaignFields?.mainTag?.[ContentfulLocale.enUS],
+          campaignFields?.additionalTags?.[ContentfulLocale.enUS]
+        )
+      )
+    } catch (error) {
+      yield put(
+        fetchCampaignFailure(
+          isErrorWithMessage(error) ? error.message : 'Error fetching campaign'
+        )
+      )
+    }
+  }
+}

--- a/src/modules/campaign/selectors.spec.ts
+++ b/src/modules/campaign/selectors.spec.ts
@@ -225,8 +225,8 @@ describe('Campaign selectors', () => {
         mockState.campaign.data = null
       })
 
-      it('should return null', () => {
-        expect(getAdditionalTags(mockState)).toBeNull()
+      it('should return an empty array', () => {
+        expect(getAdditionalTags(mockState)).toEqual([])
       })
     })
   })
@@ -363,7 +363,7 @@ describe('Campaign selectors', () => {
 
   describe('when getting banner assets', () => {
     describe('and the banner exists with assets', () => {
-      it('should return assets associated with the banner', () => {
+      it('should return the assets associated with the banner', () => {
         expect(getBannerAssets(mockState, 'banner1')).toEqual({
           asset1: mockAsset
         })

--- a/src/modules/campaign/selectors.spec.ts
+++ b/src/modules/campaign/selectors.spec.ts
@@ -1,0 +1,389 @@
+import { ContentfulLocale, ContentfulAsset, BannerFields } from '@dcl/schemas'
+import { TranslationState } from '../translation/reducer'
+import { fetchCampaignRequest } from './actions'
+import {
+  getState,
+  getData,
+  getLoading,
+  getError,
+  isLoading,
+  getMainTag,
+  getAllTags,
+  getAssets,
+  getTabName,
+  getBanner,
+  getBannerAssets,
+  getCampaignName,
+  getAdditionalTags,
+  getContentfulNormalizedLocale
+} from './selectors'
+import { CampaignState } from './types'
+
+type MockState = {
+  campaign: CampaignState
+  translation: TranslationState
+}
+
+let mockState: MockState
+let mockAsset: ContentfulAsset
+let mockBanner: BannerFields
+
+describe('Campaign selectors', () => {
+  beforeEach(() => {
+    mockAsset = {
+      metadata: {
+        tags: [],
+        concepts: []
+      },
+      sys: {
+        id: 'asset1',
+        type: 'Asset',
+        space: { sys: { type: 'Link', linkType: 'Space', id: 'space1' } },
+        createdAt: '2021-01-01',
+        updatedAt: '2021-01-01',
+        environment: {
+          sys: { type: 'Link', linkType: 'Environment', id: 'env1' }
+        },
+        publishedVersion: 1,
+        revision: 1
+      },
+      fields: {
+        title: {
+          'en-US': 'Test Banner'
+        },
+        description: {
+          'en-US': 'Test Description'
+        },
+        file: {
+          'en-US': {
+            url: 'test-url',
+            details: {
+              size: 123
+            },
+            fileName: 'test.png',
+            contentType: 'image/png'
+          }
+        }
+      }
+    }
+
+    mockBanner = {
+      fullSizeBackground: {
+        'en-US': {
+          sys: {
+            type: 'Link',
+            linkType: 'Asset',
+            id: 'asset1'
+          }
+        }
+      }
+    } as BannerFields
+
+    mockState = {
+      campaign: {
+        data: {
+          name: {
+            'en-US': 'Test Campaign'
+          },
+          tabName: {
+            'en-US': 'testTab'
+          },
+          mainTag: 'main',
+          additionalTags: ['tag1', 'tag2'],
+          banners: {
+            banner1: mockBanner
+          },
+          assets: {
+            asset1: mockAsset
+          }
+        },
+        loading: [],
+        error: null
+      },
+      translation: {
+        data: {},
+        locale: 'en',
+        loading: [],
+        error: null
+      }
+    }
+  })
+
+  describe('when getting the campaign state', () => {
+    it('should return the campaign state', () => {
+      expect(getState(mockState)).toEqual(mockState.campaign)
+    })
+  })
+
+  describe('when getting the campaign data', () => {
+    describe('and the data exists', () => {
+      it('should return the campaign data', () => {
+        expect(getData(mockState)).toEqual(mockState.campaign.data)
+      })
+    })
+
+    describe('and there is no data', () => {
+      beforeEach(() => {
+        mockState.campaign.data = null
+      })
+
+      it('should return null', () => {
+        expect(getData(mockState)).toBeNull()
+      })
+    })
+  })
+
+  describe('when getting the loading state', () => {
+    it('should return the loading state', () => {
+      expect(getLoading(mockState)).toEqual(mockState.campaign.loading)
+    })
+  })
+
+  describe('when getting the error state', () => {
+    describe('and there is no error', () => {
+      it('should return null', () => {
+        expect(getError(mockState)).toBeNull()
+      })
+    })
+
+    describe('and there is an error', () => {
+      beforeEach(() => {
+        mockState.campaign.error = 'Test error'
+      })
+
+      it('should return the error message', () => {
+        expect(getError(mockState)).toBe('Test error')
+      })
+    })
+  })
+
+  describe('when checking if the campaign is loading', () => {
+    describe('and there is no fetch request in progress', () => {
+      it('should return false', () => {
+        expect(isLoading(mockState)).toBe(false)
+      })
+    })
+
+    describe('and there is a fetch request in progress', () => {
+      beforeEach(() => {
+        mockState.campaign.loading = [fetchCampaignRequest()]
+      })
+
+      it('should return true', () => {
+        expect(isLoading(mockState)).toBe(true)
+      })
+    })
+  })
+
+  describe('when getting the main tag', () => {
+    describe('and the data exists', () => {
+      it('should return the main tag', () => {
+        expect(getMainTag(mockState)).toBe('main')
+      })
+    })
+
+    describe('and there is no data', () => {
+      beforeEach(() => {
+        mockState.campaign.data = null
+      })
+
+      it('should return undefined', () => {
+        expect(getMainTag(mockState)).toBeUndefined()
+      })
+    })
+  })
+
+  describe('when getting the campaign name', () => {
+    describe('and the data exists', () => {
+      it('should return the campaign name', () => {
+        expect(getCampaignName(mockState)).toEqual({
+          'en-US': 'Test Campaign'
+        })
+      })
+    })
+
+    describe('and there is no data', () => {
+      beforeEach(() => {
+        mockState.campaign.data = null
+      })
+
+      it('should return null', () => {
+        expect(getCampaignName(mockState)).toBeNull()
+      })
+    })
+  })
+
+  describe('when getting additional tags', () => {
+    describe('and the data exists', () => {
+      it('should return the additional tags', () => {
+        expect(getAdditionalTags(mockState)).toEqual(['tag1', 'tag2'])
+      })
+    })
+
+    describe('and there is no data', () => {
+      beforeEach(() => {
+        mockState.campaign.data = null
+      })
+
+      it('should return null', () => {
+        expect(getAdditionalTags(mockState)).toBeNull()
+      })
+    })
+  })
+
+  describe('when getting the contentful normalized locale', () => {
+    describe('and the locale is en', () => {
+      beforeEach(() => {
+        mockState.translation.locale = 'en'
+      })
+
+      it('should return en-US', () => {
+        expect(getContentfulNormalizedLocale(mockState)).toBe(
+          ContentfulLocale.enUS
+        )
+      })
+    })
+
+    describe('and the locale is es', () => {
+      beforeEach(() => {
+        mockState.translation.locale = 'es'
+      })
+
+      it('should return es', () => {
+        expect(getContentfulNormalizedLocale(mockState)).toBe(
+          ContentfulLocale.es
+        )
+      })
+    })
+
+    describe('and the locale is zh', () => {
+      beforeEach(() => {
+        mockState.translation.locale = 'zh'
+      })
+
+      it('should return zh', () => {
+        expect(getContentfulNormalizedLocale(mockState)).toBe(
+          ContentfulLocale.zh
+        )
+      })
+    })
+
+    describe('and the locale is not supported', () => {
+      beforeEach(() => {
+        mockState.translation.locale = 'fr'
+      })
+
+      it('should return en-US', () => {
+        expect(getContentfulNormalizedLocale(mockState)).toBe(
+          ContentfulLocale.enUS
+        )
+      })
+    })
+  })
+
+  describe('when getting all tags', () => {
+    describe('and the data exists', () => {
+      it('should return all tags including main tag', () => {
+        expect(getAllTags(mockState)).toEqual(['main', 'tag1', 'tag2'])
+      })
+    })
+
+    describe('and there is no data', () => {
+      beforeEach(() => {
+        mockState.campaign.data = null
+      })
+
+      it('should return an empty array', () => {
+        expect(getAllTags(mockState)).toEqual([])
+      })
+    })
+  })
+
+  describe('when getting assets', () => {
+    describe('and the data exists', () => {
+      it('should return the assets', () => {
+        expect(getAssets(mockState)).toEqual(mockState.campaign.data?.assets)
+      })
+    })
+
+    describe('and there is no data', () => {
+      beforeEach(() => {
+        mockState.campaign.data = null
+      })
+
+      it('should return null', () => {
+        expect(getAssets(mockState)).toBeNull()
+      })
+    })
+  })
+
+  describe('when getting the tab name', () => {
+    describe('and the data exists', () => {
+      it('should return the tab name', () => {
+        expect(getTabName(mockState)).toEqual({
+          'en-US': 'testTab'
+        })
+      })
+    })
+
+    describe('and there is no data', () => {
+      beforeEach(() => {
+        mockState.campaign.data = null
+      })
+
+      it('should return null', () => {
+        expect(getTabName(mockState)).toBeNull()
+      })
+    })
+  })
+
+  describe('when getting a banner', () => {
+    describe('and the banner exists', () => {
+      it('should return the banner', () => {
+        expect(getBanner(mockState, 'banner1')).toEqual(mockBanner)
+      })
+    })
+
+    describe('and the banner does not exist', () => {
+      it('should return null', () => {
+        expect(getBanner(mockState, 'nonexistent')).toBeNull()
+      })
+    })
+
+    describe('and there is no data', () => {
+      beforeEach(() => {
+        mockState.campaign.data = null
+      })
+
+      it('should return null', () => {
+        expect(getBanner(mockState, 'banner1')).toBeNull()
+      })
+    })
+  })
+
+  describe('when getting banner assets', () => {
+    describe('and the banner exists with assets', () => {
+      it('should return assets associated with the banner', () => {
+        expect(getBannerAssets(mockState, 'banner1')).toEqual({
+          asset1: mockAsset
+        })
+      })
+    })
+
+    describe('and the banner does not exist', () => {
+      it('should return an empty object', () => {
+        expect(getBannerAssets(mockState, 'nonexistent')).toEqual({})
+      })
+    })
+
+    describe('and there are no assets', () => {
+      beforeEach(() => {
+        mockState.campaign.data!.assets = {}
+      })
+
+      it('should return an empty object', () => {
+        expect(getBannerAssets(mockState, 'banner1')).toEqual({})
+      })
+    })
+  })
+})

--- a/src/modules/campaign/selectors.ts
+++ b/src/modules/campaign/selectors.ts
@@ -11,10 +11,11 @@ export const getError = (state: any): string | null => getState(state).error
 export const isLoading = (state: any): boolean => isLoadingType(getLoading(state), FETCH_CAMPAIGN_REQUEST)
 export const getMainTag = (state: any): string | undefined => getData(state)?.mainTag
 export const getCampaignName = (state: any): LocalizedField<string> | null => getData(state)?.name || null
-export const getAdditionalTags = (state: any): string[] | null => getData(state)?.additionalTags || null
+export const getAdditionalTags = (state: any): string[] => getData(state)?.additionalTags ?? []
 export const getAllTags = (state: any): string[] => {
-  const data = getData(state)
-  return [data?.mainTag, ...(data?.additionalTags ?? [])].filter(Boolean) as string[]
+  const mainTag = getMainTag(state)
+  const additionalTags = getAdditionalTags(state)
+  return [mainTag, ...additionalTags].filter(Boolean) as string[]
 }
 export const getAssets = (state: any): Record<string, ContentfulAsset> | null => getData(state)?.assets || null
 export const getTabName = (state: any): LocalizedField<string> | null => getData(state)?.tabName || null

--- a/src/modules/campaign/selectors.ts
+++ b/src/modules/campaign/selectors.ts
@@ -1,0 +1,46 @@
+import { BannerFields, ContentfulAsset, ContentfulLocale, LocalizedField, isSysLink } from '@dcl/schemas'
+import { getLocale } from '../translation'
+import { isLoadingType, type LoadingState } from '../loading'
+import { CampaignState } from './types'
+import { FETCH_CAMPAIGN_REQUEST } from './actions'
+
+export const getState = (state: any): CampaignState => state.campaign
+export const getData = (state: any): CampaignState['data'] | null => getState(state).data
+export const getLoading = (state: any): LoadingState => getState(state).loading
+export const getError = (state: any): string | null => getState(state).error
+export const isLoading = (state: any): boolean => isLoadingType(getLoading(state), FETCH_CAMPAIGN_REQUEST)
+export const getMainTag = (state: any): string | undefined => getData(state)?.mainTag
+export const getCampaignName = (state: any): LocalizedField<string> | null => getData(state)?.name || null
+export const getAdditionalTags = (state: any): string[] | null => getData(state)?.additionalTags || null
+export const getAllTags = (state: any): string[] => {
+  const data = getData(state)
+  return [data?.mainTag, ...(data?.additionalTags ?? [])].filter(Boolean) as string[]
+}
+export const getAssets = (state: any): Record<string, ContentfulAsset> | null => getData(state)?.assets || null
+export const getTabName = (state: any): LocalizedField<string> | null => getData(state)?.tabName || null
+export const getBanner = (state: any, id: string): BannerFields | null => {
+  return getData(state)?.banners[id] ?? null
+}
+export const getBannerAssets = (state: any, bannerId: string): Record<string, ContentfulAsset> => {
+  const assets = getAssets(state)
+  const banner = getBanner(state, bannerId)
+
+  if (!banner) return {}
+
+  return Object.entries(banner).reduce((acc, [_, value]) => {
+    if (isSysLink(value['en-US'])) {
+      const asset = assets?.[value['en-US'].sys.id]
+      if (asset) {
+        acc[value['en-US'].sys.id] = asset
+      }
+    }
+    return acc
+  }, {} as Record<string, ContentfulAsset>)
+}
+export const getContentfulNormalizedLocale = (state: any): ContentfulLocale => {
+  const storeLocale = getLocale(state)
+  if (!['en', 'zh', 'es'].includes(storeLocale)) {
+    return ContentfulLocale.enUS
+  }
+  return storeLocale === 'en' ? ContentfulLocale.enUS : (storeLocale as ContentfulLocale)
+}

--- a/src/modules/campaign/types.ts
+++ b/src/modules/campaign/types.ts
@@ -1,0 +1,19 @@
+import { ContentfulAsset, BannerFields, LocalizedField } from '@dcl/schemas'
+import { ActionType } from 'typesafe-actions'
+import { LoadingState } from '../loading/reducer'
+import * as actions from './actions'
+
+export type CampaignState = {
+  data: {
+    name?: LocalizedField<string>
+    tabName?: LocalizedField<string>
+    mainTag?: string
+    additionalTags?: string[]
+    banners: Record<string, BannerFields>
+    assets: Record<string, ContentfulAsset>
+  } | null
+  loading: LoadingState
+  error: string | null
+}
+
+export type CampaignAction = ActionType<typeof actions>

--- a/src/tests/contentfulMocks.ts
+++ b/src/tests/contentfulMocks.ts
@@ -1,0 +1,592 @@
+import {
+  ContentfulAsset,
+  ContentfulEntry,
+  MarketingAdminFields,
+  CampaignFields,
+  BannerFields
+} from '@dcl/schemas'
+
+const mockAdminEntry: ContentfulEntry<MarketingAdminFields> = {
+  metadata: {
+    tags: [],
+    concepts: []
+  },
+  sys: {
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: 'ea2ybdmmn1kv'
+      }
+    },
+    id: '3mvjCEsGUUqL22BY1vZLmZ',
+    type: 'Entry',
+    createdAt: '2025-01-14T19:01:37.139Z',
+    updatedAt: '2025-01-17T13:10:03.829Z',
+    environment: {
+      sys: {
+        id: 'development',
+        type: 'Link',
+        linkType: 'Environment'
+      }
+    },
+    publishedVersion: 14,
+    revision: 3,
+    contentType: {
+      sys: {
+        type: 'Link',
+        linkType: 'ContentType',
+        id: 'admin'
+      }
+    }
+  },
+  fields: {
+    name: {
+      'en-US': 'Unique admin entity'
+    },
+    campaign: {
+      'en-US': {
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: '7luqOR5Qdl8siwdQ8hscEW'
+        }
+      }
+    },
+    marketplaceHomepageBanner: {
+      'en-US': {
+        sys: {
+          type: 'Link',
+          linkType: 'Entry',
+          id: '2maJ4UuoqaYtbZxVGymsJo'
+        }
+      }
+    }
+  }
+}
+
+const mockCampaignEntry: ContentfulEntry<CampaignFields> = {
+  metadata: {
+    tags: [],
+    concepts: []
+  },
+  sys: {
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: 'ea2ybdmmn1kv'
+      }
+    },
+    id: '7luqOR5Qdl8siwdQ8hscEW',
+    type: 'Entry',
+    createdAt: '2025-01-14T17:04:54.159Z',
+    updatedAt: '2025-01-20T14:39:39.699Z',
+    environment: {
+      sys: {
+        id: 'development',
+        type: 'Link',
+        linkType: 'Environment'
+      }
+    },
+    publishedVersion: 24,
+    revision: 7,
+    contentType: {
+      sys: {
+        type: 'Link',
+        linkType: 'ContentType',
+        id: 'marketingCampaign'
+      }
+    }
+  },
+  fields: {
+    name: {
+      'en-US': 'Metaverse Festival 2024',
+      es: 'Festival del metaverso 2024',
+      zh: '2024 年元宇宙节'
+    },
+    marketplaceTabName: {
+      'en-US': 'MVF2024',
+      es: 'MVF2024',
+      zh: 'MVF2024'
+    },
+    mainTag: {
+      'en-US': 'MVF2024'
+    }
+  }
+}
+
+const mockHomepageBannerEntry: ContentfulEntry<BannerFields> = {
+  metadata: {
+    tags: [],
+    concepts: []
+  },
+  sys: {
+    space: {
+      sys: {
+        type: 'Link',
+        linkType: 'Space',
+        id: 'ea2ybdmmn1kv'
+      }
+    },
+    id: '2maJ4UuoqaYtbZxVGymsJo',
+    type: 'Entry',
+    createdAt: '2025-01-07T18:43:08.572Z',
+    updatedAt: '2025-01-15T17:23:51.474Z',
+    environment: {
+      sys: {
+        id: 'development',
+        type: 'Link',
+        linkType: 'Environment'
+      }
+    },
+    publishedVersion: 50,
+    revision: 12,
+    contentType: {
+      sys: {
+        type: 'Link',
+        linkType: 'ContentType',
+        id: 'banner'
+      }
+    }
+  },
+  fields: {
+    desktopTitle: {
+      'en-US': 'Prepare Your Galactic Looks!',
+      es: 'Prepara tus looks galácticos!',
+      zh: '准备好你的银河外观！'
+    },
+    desktopTitleAlignment: {
+      'en-US': 'Left'
+    },
+    mobileTitle: {
+      'en-US': 'Prepare Your Galactic Looks!',
+      es: 'Prepara tus looks galácticos!',
+      zh: '准备好你的银河外观！'
+    },
+    mobileTitleAlignment: {
+      'en-US': 'Center'
+    },
+    desktopText: {
+      'en-US': {
+        data: {},
+        content: [
+          {
+            data: {},
+            content: [
+              {
+                data: {},
+                marks: [],
+                value:
+                  "Get ready to show off your out of this world style at this year's music festival ",
+                nodeType: 'text'
+              },
+              {
+                data: {},
+                marks: [
+                  {
+                    type: 'bold'
+                  }
+                ],
+                value: 'Nov 20-23',
+                nodeType: 'text'
+              },
+              {
+                data: {},
+                marks: [],
+                value: '!',
+                nodeType: 'text'
+              }
+            ],
+            nodeType: 'paragraph'
+          },
+          {
+            data: {},
+            content: [
+              {
+                data: {},
+                marks: [],
+                value: 'Use the ',
+                nodeType: 'text'
+              },
+              {
+                data: {},
+                marks: [
+                  {
+                    type: 'italic'
+                  }
+                ],
+                value: 'DCLMF24',
+                nodeType: 'text'
+              },
+              {
+                data: {},
+                marks: [],
+                value:
+                  ' tab to find everything you will need to be festival ready all in ',
+                nodeType: 'text'
+              },
+              {
+                data: {},
+                marks: [
+                  {
+                    type: 'underline'
+                  }
+                ],
+                value: 'one place',
+                nodeType: 'text'
+              },
+              {
+                data: {},
+                marks: [],
+                value: '.',
+                nodeType: 'text'
+              }
+            ],
+            nodeType: 'paragraph'
+          }
+        ],
+        nodeType: 'document'
+      },
+      es: {
+        nodeType: 'document',
+        data: {},
+        content: [
+          {
+            nodeType: 'paragraph',
+            data: {},
+            content: [
+              {
+                nodeType: 'text',
+                value:
+                  '¡Prepárate para mostrar tu estilo fuera de lo común en el festival de música de este año, que se realizará del 20 al 23 de noviembre!',
+                marks: [],
+                data: {}
+              }
+            ]
+          },
+          {
+            nodeType: 'paragraph',
+            data: {},
+            content: [
+              {
+                nodeType: 'text',
+                value:
+                  'Usa la pestaña DCLMF24 para encontrar todo lo que necesitas para estar listo para el festival, todo en un solo lugar.',
+                marks: [],
+                data: {}
+              }
+            ]
+          }
+        ]
+      },
+      zh: {
+        data: {},
+        content: [
+          {
+            data: {},
+            content: [
+              {
+                data: {},
+                marks: [],
+                value:
+                  '准备好在 11 月 20 日至 23 日举行的今年音乐节上展示您非凡的风格吧！使用 DCLMF24 选项卡，在一个地方找到您参加音乐节所需的一切。',
+                nodeType: 'text'
+              }
+            ],
+            nodeType: 'paragraph'
+          }
+        ],
+        nodeType: 'document'
+      }
+    },
+    desktopTextAlignment: {
+      'en-US': 'Left'
+    },
+    mobileText: {
+      'en-US': {
+        data: {},
+        content: [
+          {
+            data: {},
+            content: [
+              {
+                data: {},
+                marks: [],
+                value:
+                  "Get ready to show off your out of this world style at this year's music festival ",
+                nodeType: 'text'
+              },
+              {
+                data: {},
+                marks: [
+                  {
+                    type: 'bold'
+                  }
+                ],
+                value: 'Nov 20-23',
+                nodeType: 'text'
+              },
+              {
+                data: {},
+                marks: [],
+                value: '!',
+                nodeType: 'text'
+              }
+            ],
+            nodeType: 'paragraph'
+          }
+        ],
+        nodeType: 'document'
+      },
+      es: {
+        data: {},
+        content: [
+          {
+            data: {},
+            content: [
+              {
+                data: {},
+                marks: [],
+                value:
+                  '¡Prepárate para mostrar tu estilo fuera de lo común en el festival de música de este año, que se realizará del 20 al 23 de noviembre!',
+                nodeType: 'text'
+              }
+            ],
+            nodeType: 'paragraph'
+          }
+        ],
+        nodeType: 'document'
+      },
+      zh: {
+        data: {},
+        content: [
+          {
+            data: {},
+            content: [
+              {
+                data: {},
+                marks: [],
+                value:
+                  '准备好在 11 月 20 日至 23 日举行的今年音乐节上展示您非凡的风格吧！',
+                nodeType: 'text'
+              }
+            ],
+            nodeType: 'paragraph'
+          }
+        ],
+        nodeType: 'document'
+      }
+    },
+    mobileTextAlignment: {
+      'en-US': 'Left'
+    },
+    showButton: {
+      'en-US': true
+    },
+    buttonLink: {
+      'en-US': 'https://google.com'
+    },
+    buttonsText: {
+      'en-US': 'Shop now',
+      es: 'Comprar ahora',
+      zh: '立即购买'
+    },
+    desktopButtonAlignment: {
+      'en-US': 'Left'
+    },
+    mobileButtonAlignment: {
+      'en-US': 'Center'
+    },
+    fullSizeBackground: {
+      'en-US': {
+        sys: {
+          type: 'Link',
+          linkType: 'Asset',
+          id: '6E1rR9gejaDnaXQbRPifFe'
+        }
+      }
+    },
+    mobileBackground: {
+      'en-US': {
+        sys: {
+          type: 'Link',
+          linkType: 'Asset',
+          id: '4r6BTqYTzJViXYDhowTMJm'
+        }
+      }
+    },
+    logo: {
+      'en-US': {
+        sys: {
+          type: 'Link',
+          linkType: 'Asset',
+          id: '2fPc6zxkPEIJcI3jUBTdOo'
+        }
+      }
+    }
+  }
+}
+
+const marketplaceHomepageBannerAssets: ContentfulAsset[] = [
+  {
+    metadata: {
+      tags: [],
+      concepts: []
+    },
+    sys: {
+      space: {
+        sys: {
+          type: 'Link',
+          linkType: 'Space',
+          id: 'ea2ybdmmn1kv'
+        }
+      },
+      id: '2fPc6zxkPEIJcI3jUBTdOo',
+      type: 'Asset',
+      createdAt: '2025-01-09T17:55:26.842Z',
+      updatedAt: '2025-01-09T17:55:26.842Z',
+      environment: {
+        sys: {
+          id: 'development',
+          type: 'Link',
+          linkType: 'Environment'
+        }
+      },
+      publishedVersion: 5,
+      revision: 1
+    },
+    fields: {
+      title: {
+        'en-US': 'Metarverse Festival 2024 Logo'
+      },
+      description: {
+        'en-US': ''
+      },
+      file: {
+        'en-US': {
+          url:
+            '//images.ctfassets.net/ea2ybdmmn1kv/2fPc6zxkPEIJcI3jUBTdOo/1454c71d341ff247c9563e3108e025ff/logo.webp',
+          details: {
+            size: 441546,
+            image: {
+              width: 960,
+              height: 211
+            }
+          },
+          fileName: 'logo.webp',
+          contentType: 'image/webp'
+        }
+      }
+    }
+  },
+  {
+    metadata: {
+      tags: [],
+      concepts: []
+    },
+    sys: {
+      space: {
+        sys: {
+          type: 'Link',
+          linkType: 'Space',
+          id: 'ea2ybdmmn1kv'
+        }
+      },
+      id: '4r6BTqYTzJViXYDhowTMJm',
+      type: 'Asset',
+      createdAt: '2025-01-07T18:41:30.547Z',
+      updatedAt: '2025-01-07T18:41:30.547Z',
+      environment: {
+        sys: {
+          id: 'development',
+          type: 'Link',
+          linkType: 'Environment'
+        }
+      },
+      publishedVersion: 6,
+      revision: 1
+    },
+    fields: {
+      title: {
+        'en-US': 'Marketplace Mobile Banner Test'
+      },
+      description: {
+        'en-US': 'Marketplace mobile banner.'
+      },
+      file: {
+        'en-US': {
+          url:
+            '//images.ctfassets.net/ea2ybdmmn1kv/4r6BTqYTzJViXYDhowTMJm/86510732bc7732625ad3581d4bd14eb3/static-390-390.jpg',
+          details: {
+            size: 44180,
+            image: {
+              width: 390,
+              height: 390
+            }
+          },
+          fileName: 'static-390-390.jpg',
+          contentType: 'image/jpeg'
+        }
+      }
+    }
+  },
+  {
+    metadata: {
+      tags: [],
+      concepts: []
+    },
+    sys: {
+      space: {
+        sys: {
+          type: 'Link',
+          linkType: 'Space',
+          id: 'ea2ybdmmn1kv'
+        }
+      },
+      id: '6E1rR9gejaDnaXQbRPifFe',
+      type: 'Asset',
+      createdAt: '2025-01-07T18:39:55.992Z',
+      updatedAt: '2025-01-07T18:39:55.992Z',
+      environment: {
+        sys: {
+          id: 'development',
+          type: 'Link',
+          linkType: 'Environment'
+        }
+      },
+      publishedVersion: 7,
+      revision: 1
+    },
+    fields: {
+      title: {
+        'en-US': 'Marketplace Banner Full Background Test'
+      },
+      description: {
+        'en-US': ''
+      },
+      file: {
+        'en-US': {
+          url:
+            '//images.ctfassets.net/ea2ybdmmn1kv/6E1rR9gejaDnaXQbRPifFe/7638d286960c0269125543c23faf8312/static-1920-300.jpg',
+          details: {
+            size: 117325,
+            image: {
+              width: 1920,
+              height: 300
+            }
+          },
+          fileName: 'static-1920-300.jpg',
+          contentType: 'image/jpeg'
+        }
+      }
+    }
+  }
+]
+
+export {
+  mockAdminEntry,
+  mockHomepageBannerEntry,
+  mockCampaignEntry,
+  marketplaceHomepageBannerAssets
+}


### PR DESCRIPTION
This PR adds the campaign module and the banner container.
The campaign module is in charge of communicating with Contentful to retrieve the admin entries which has linked banners and a campaign entity. It processes the localized information about those entries and stores it in the redux store.