### PR TITLE
fix: Use current locale for the banners

### DIFF
--- a/src/containers/Banner/Banner.container.ts
+++ b/src/containers/Banner/Banner.container.ts
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import {
   getBanner,
   getBannerAssets,
+  getContentfulNormalizedLocale,
   getError,
   isLoading
 } from '../../modules/campaign'
@@ -12,7 +13,8 @@ const mapState = (state: any, ownProps: OwnProps): MapStateProps => ({
   fields: getBanner(state, ownProps.id) ?? null,
   assets: getBannerAssets(state, ownProps.id),
   isLoading: isLoading(state),
-  error: getError(state)
+  error: getError(state),
+  locale: getContentfulNormalizedLocale(state)
 })
 
 export default connect<MapStateProps, {}, OwnProps>(mapState)(Banner)

--- a/src/containers/Banner/Banner.types.ts
+++ b/src/containers/Banner/Banner.types.ts
@@ -7,5 +7,5 @@ export type BannerProps = Omit<UIBannerProps, 'fields'> & {
 export type OwnProps = Pick<BannerProps, 'id'>
 export type MapStateProps = Pick<
   BannerProps,
-  'fields' | 'assets' | 'isLoading' | 'error'
+  'fields' | 'assets' | 'isLoading' | 'error' | 'locale'
 >


### PR DESCRIPTION
This PR changes the way we're loading the banners to set the locale as the current site's locale.