### PR TITLE
BREAKING: Update the decentraland-connnect dependency to use Magic's OAuthV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1465,7 +1465,6 @@ import { Switch, Route } from 'react-router-dom'
 import SignInPage from 'decentraland-dapps/dist/containers/SignInPage'
 
 //...
-
 <Switch>
   <Route exact path='/' component={...} />
   {/* your dapps routes... */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "axios": "^0.21.1",
         "date-fns": "^1.29.0",
         "dcl-catalyst-client": "^21.1.0",
-        "decentraland-connect": "^8.0.0",
+        "decentraland-connect": "^8.0.1",
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^2.18.0",
         "decentraland-ui": "^6.11.0",
@@ -8527,9 +8527,9 @@
       }
     },
     "node_modules/decentraland-connect": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-8.0.0.tgz",
-      "integrity": "sha512-n/GspaGZdgvMEiZ9EmmeN8PnCCpOFFsrBVsxUapLQxLGzrglmy1x8G5WA/FGVhF62p76r2I2YpdYq5SSXTEZUA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-8.0.1.tgz",
+      "integrity": "sha512-SU8va4voYFfh+rNqyLs6N3/1N8n7ND29IX4cqBqBgL++vAD0nyr/QwXc5HEPmoMrNV1tdMs239yXsDckalwemg==",
       "dependencies": {
         "@dcl/schemas": "^15.1.2",
         "@dcl/single-sign-on-client": "^0.1.0",
@@ -8541,26 +8541,26 @@
         "@web3-react/network-connector": "^6.1.3",
         "@web3-react/walletlink-connector": "^6.2.13",
         "ethers": "^6.9.1",
-        "magic-sdk": "^28.19.1",
+        "magic-sdk": "^27.0.0",
         "socket.io-client": "^4.7.2",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/decentraland-connect/node_modules/@magic-sdk/commons": {
-      "version": "24.20.0",
-      "resolved": "https://registry.npmjs.org/@magic-sdk/commons/-/commons-24.20.0.tgz",
-      "integrity": "sha512-7uOWqqXzV7eHXo8NAoKDTkp5QqeHN2LUN7K6AtCSM8cPq4Auil/5o6hTSF/6sD4pxn70IKCi1P6x+umnYn5BEg==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@magic-sdk/commons/-/commons-23.0.0.tgz",
+      "integrity": "sha512-y94UJG9WRrSnxTh6+WnLAvSRjYmE1/kJtTABD/MWJcIIN/qY7LV3mBdY6PzcYbhXvcz2jedmZ2YPnzVWJgJCrA==",
       "peerDependencies": {
         "@magic-sdk/provider": ">=18.6.0",
         "@magic-sdk/types": ">=15.8.0"
       }
     },
     "node_modules/decentraland-connect/node_modules/@magic-sdk/provider": {
-      "version": "28.20.0",
-      "resolved": "https://registry.npmjs.org/@magic-sdk/provider/-/provider-28.20.0.tgz",
-      "integrity": "sha512-BmNfctAABoUX0iyCx15a753XL796V2fY1nGtVBIk4zyW5ZGqfF6poVQ9MlJDf0TqyPm1Ff+9qHZsazUP6YjoSg==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@magic-sdk/provider/-/provider-27.0.0.tgz",
+      "integrity": "sha512-k2haK2zhYkqf+cbMF+/HKvqa8qPWqdZbW10qgN6AdqaOE750ceC3GDQCUwAfkzdofmWrRtFgW5jVAVCVz5WklQ==",
       "dependencies": {
-        "@magic-sdk/types": "^24.18.0",
+        "@magic-sdk/types": "^23.0.0",
         "eventemitter3": "^4.0.4",
         "web3-core": "1.5.2"
       },
@@ -8569,9 +8569,9 @@
       }
     },
     "node_modules/decentraland-connect/node_modules/@magic-sdk/types": {
-      "version": "24.18.0",
-      "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-24.18.0.tgz",
-      "integrity": "sha512-6HS9WMgzLNCkvkJeDZW8+/maP8JInDYqnfudp/SgPWMosm9l6zH3X+x+ntDjRIUm5Qdugsg+L1fxMBj48r616Q=="
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-23.0.0.tgz",
+      "integrity": "sha512-NTjgGPJVYxoncSrHtDZLDiJzdSbxHV0jCy6J+YvT+LY7QUiGY3zzu+NhLqgLxE6KZODXERhSLYSimotcokZbmw=="
     },
     "node_modules/decentraland-connect/node_modules/@noble/hashes": {
       "version": "1.3.2",
@@ -8622,13 +8622,13 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/decentraland-connect/node_modules/magic-sdk": {
-      "version": "28.21.0",
-      "resolved": "https://registry.npmjs.org/magic-sdk/-/magic-sdk-28.21.0.tgz",
-      "integrity": "sha512-aT/ReZLXNRccfxNw8YfYjHxTf4/9qq/gA8loCF2XN0W9E/6dx1RUpaRVtVsBSO2HQcLpj83GNIKAL554kagfkQ==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/magic-sdk/-/magic-sdk-27.0.0.tgz",
+      "integrity": "sha512-FpLHSR6+OC4JYOqRE0dX8u7qGOa6L9bxdGIODlB6DUyuoO0jxghKxlAqGE2ZAMVkJEwwTV8Mm3JZCZxtf2eGJg==",
       "dependencies": {
-        "@magic-sdk/commons": "^24.20.0",
-        "@magic-sdk/provider": "^28.20.0",
-        "@magic-sdk/types": "^24.18.0",
+        "@magic-sdk/commons": "^23.0.0",
+        "@magic-sdk/provider": "^27.0.0",
+        "@magic-sdk/types": "^23.0.0",
         "localforage": "^1.7.4"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "axios": "^0.21.1",
         "date-fns": "^1.29.0",
         "dcl-catalyst-client": "^21.1.0",
-        "decentraland-connect": "^7.3.2",
+        "decentraland-connect": "^8.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^2.18.0",
         "decentraland-ui": "^6.11.0",
@@ -3686,6 +3686,14 @@
       "version": "15.5.0",
       "resolved": "https://registry.npmjs.org/@magic-ext/oauth/-/oauth-15.5.0.tgz",
       "integrity": "sha512-q9k5IrFwzaVLJauoHmnj11r7bJQ22PZ41CEys3GmDpLB5Xz5iavqB2vyGkZz1r7bU48i5ZqK0qyvQe7it4j4YA==",
+      "dependencies": {
+        "crypto-js": "^3.3.0"
+      }
+    },
+    "node_modules/@magic-ext/oauth2": {
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@magic-ext/oauth2/-/oauth2-9.21.0.tgz",
+      "integrity": "sha512-43KvjPg8xxqSYo0W8mVcFcotCo78p3JZNQ+O8P83qvkyTxe8ZAPwBUbSxDLKvBqlcnxvRkz7vru+M/B7Vx4ezg==",
       "dependencies": {
         "crypto-js": "^3.3.0"
       }
@@ -8519,13 +8527,13 @@
       }
     },
     "node_modules/decentraland-connect": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-7.3.2.tgz",
-      "integrity": "sha512-0VUrAMhiM/IcavuFHWXvi5ZVkoIv20TpKcKS+8IHiIqYmK6wj9g7y2Zq8tnrp1qp7du9no771nv4KisB/m/sNA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-8.0.0.tgz",
+      "integrity": "sha512-n/GspaGZdgvMEiZ9EmmeN8PnCCpOFFsrBVsxUapLQxLGzrglmy1x8G5WA/FGVhF62p76r2I2YpdYq5SSXTEZUA==",
       "dependencies": {
         "@dcl/schemas": "^15.1.2",
         "@dcl/single-sign-on-client": "^0.1.0",
-        "@magic-ext/oauth": "^15.5.0",
+        "@magic-ext/oauth2": "^9.19.0",
         "@walletconnect/ethereum-provider": "^2.17.1",
         "@walletconnect/modal": "^2.6.2",
         "@web3-react/fortmatic-connector": "^6.1.6",
@@ -8533,10 +8541,37 @@
         "@web3-react/network-connector": "^6.1.3",
         "@web3-react/walletlink-connector": "^6.2.13",
         "ethers": "^6.9.1",
-        "magic-sdk": "^21.4.1",
+        "magic-sdk": "^28.19.1",
         "socket.io-client": "^4.7.2",
         "tslib": "^2.6.2"
       }
+    },
+    "node_modules/decentraland-connect/node_modules/@magic-sdk/commons": {
+      "version": "24.20.0",
+      "resolved": "https://registry.npmjs.org/@magic-sdk/commons/-/commons-24.20.0.tgz",
+      "integrity": "sha512-7uOWqqXzV7eHXo8NAoKDTkp5QqeHN2LUN7K6AtCSM8cPq4Auil/5o6hTSF/6sD4pxn70IKCi1P6x+umnYn5BEg==",
+      "peerDependencies": {
+        "@magic-sdk/provider": ">=18.6.0",
+        "@magic-sdk/types": ">=15.8.0"
+      }
+    },
+    "node_modules/decentraland-connect/node_modules/@magic-sdk/provider": {
+      "version": "28.20.0",
+      "resolved": "https://registry.npmjs.org/@magic-sdk/provider/-/provider-28.20.0.tgz",
+      "integrity": "sha512-BmNfctAABoUX0iyCx15a753XL796V2fY1nGtVBIk4zyW5ZGqfF6poVQ9MlJDf0TqyPm1Ff+9qHZsazUP6YjoSg==",
+      "dependencies": {
+        "@magic-sdk/types": "^24.18.0",
+        "eventemitter3": "^4.0.4",
+        "web3-core": "1.5.2"
+      },
+      "peerDependencies": {
+        "localforage": "^1.7.4"
+      }
+    },
+    "node_modules/decentraland-connect/node_modules/@magic-sdk/types": {
+      "version": "24.18.0",
+      "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-24.18.0.tgz",
+      "integrity": "sha512-6HS9WMgzLNCkvkJeDZW8+/maP8JInDYqnfudp/SgPWMosm9l6zH3X+x+ntDjRIUm5Qdugsg+L1fxMBj48r616Q=="
     },
     "node_modules/decentraland-connect/node_modules/@noble/hashes": {
       "version": "1.3.2",
@@ -8585,6 +8620,17 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/decentraland-connect/node_modules/magic-sdk": {
+      "version": "28.21.0",
+      "resolved": "https://registry.npmjs.org/magic-sdk/-/magic-sdk-28.21.0.tgz",
+      "integrity": "sha512-aT/ReZLXNRccfxNw8YfYjHxTf4/9qq/gA8loCF2XN0W9E/6dx1RUpaRVtVsBSO2HQcLpj83GNIKAL554kagfkQ==",
+      "dependencies": {
+        "@magic-sdk/commons": "^24.20.0",
+        "@magic-sdk/provider": "^28.20.0",
+        "@magic-sdk/types": "^24.18.0",
+        "localforage": "^1.7.4"
+      }
     },
     "node_modules/decentraland-connect/node_modules/tslib": {
       "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "axios": "^0.21.1",
     "date-fns": "^1.29.0",
     "dcl-catalyst-client": "^21.1.0",
-    "decentraland-connect": "^7.3.2",
+    "decentraland-connect": "^8.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-transactions": "^2.18.0",
     "decentraland-ui": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "axios": "^0.21.1",
     "date-fns": "^1.29.0",
     "dcl-catalyst-client": "^21.1.0",
-    "decentraland-connect": "^8.0.0",
+    "decentraland-connect": "^8.0.1",
     "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-transactions": "^2.18.0",
     "decentraland-ui": "^6.11.0",


### PR DESCRIPTION
BREAKING: Decentraland Connect now uses the OAuthV2 dependency.