### PR TITLE
fix: Network switching loader

### DIFF
--- a/src/modules/wallet/sagas.spec.ts
+++ b/src/modules/wallet/sagas.spec.ts
@@ -119,7 +119,7 @@ describe('Wallet sagas', () => {
     })
     describe('when getting the connected provider succeeds', () => {
       describe('when wallet_switchEthereumChain succeeds', () => {
-        it('should dispatch an action to signal that the request succeded', () => {
+        it('should dispatch an action to signal that the request succeeded', () => {
           return expectSaga(walletSaga)
             .provide([
               [
@@ -136,6 +136,14 @@ describe('Wallet sagas', () => {
                   timeout: delay(SWITCH_NETWORK_TIMEOUT)
                 }),
                 { switched: true }
+              ],
+              [put(fetchWalletRequest()), undefined],
+              [
+                race({
+                  success: take(FETCH_WALLET_SUCCESS),
+                  failure: take(FETCH_WALLET_FAILURE)
+                }),
+                { success: true }
               ]
             ])
             .put(switchNetworkSuccess(ChainId.ETHEREUM_MAINNET))

--- a/src/modules/wallet/sagas.ts
+++ b/src/modules/wallet/sagas.ts
@@ -46,8 +46,6 @@ import {
   SwitchNetworkRequestAction,
   switchNetworkSuccess,
   switchNetworkFailure,
-  SWITCH_NETWORK_SUCCESS,
-  SwitchNetworkSuccessAction,
   setAppChainId,
   disconnectWalletSuccess,
   disconnectWalletFailure
@@ -108,8 +106,7 @@ export function* walletSaga() {
     takeEvery(FETCH_WALLET_REQUEST, handleFetchWalletRequest),
     takeEvery(DISCONNECT_WALLET_REQUEST, handleDisconnectWalletRequest),
     takeEvery(CONNECT_WALLET_SUCCESS, handleConnectWalletSuccess),
-    takeEvery(SWITCH_NETWORK_REQUEST, handleSwitchNetworkRequest),
-    takeEvery(SWITCH_NETWORK_SUCCESS, handleSwitchNetworkSuccess)
+    takeEvery(SWITCH_NETWORK_REQUEST, handleSwitchNetworkRequest)
   ])
 }
 
@@ -222,16 +219,17 @@ function* handleSwitchNetworkRequest(action: SwitchNetworkRequestAction) {
         yield put(showToast(getSwitchChainErrorToast(chainId)))
         throw new Error('Error switching network: Operation timed out')
       } else {
+        yield put(fetchWalletRequest())
+        yield race({
+          success: take(FETCH_WALLET_SUCCESS),
+          failure: take(FETCH_WALLET_FAILURE)
+        })
         yield put(switchNetworkSuccess(chainId))
       }
     } catch (switchError) {
       yield put(switchNetworkFailure(chainId, switchError.message))
     }
   }
-}
-
-function* handleSwitchNetworkSuccess(_action: SwitchNetworkSuccessAction) {
-  yield put(fetchWalletRequest())
 }
 
 export function createWalletSaga(options: CreateWalletOptions) {


### PR DESCRIPTION
This PR changes the `switchNetwork` action so it consider the wallet fetching process as part of the network switching. This is important because the fetching of the wallet is what builds the new wallet in the store with the balances and the current selected chain.
Without this change, in some cases, specially seen with Magic, switching networks results in the switching operation finishing before the store is updated.