### PR TITLE
feat: Add manual mode to magic auto sign in authorizations

### DIFF
--- a/src/containers/withAuthorizedAction/withAuthorizedAction.tsx
+++ b/src/containers/withAuthorizedAction/withAuthorizedAction.tsx
@@ -19,7 +19,7 @@ import {
   authorizationFlowRequest
 } from '../../modules/authorization/actions'
 import { getIsFeatureEnabled } from '../../modules/features/selectors'
-import { ApplicationName } from '../../modules/features'
+import { ApplicationName, FeatureName } from '../../modules/features'
 import { isWeb2Wallet } from '../../modules/wallet/utils/providerChecks'
 import {
   getAuthorizationFlowError,
@@ -41,13 +41,11 @@ import {
   AuthorizationTranslationKeys
 } from './withAuthorizedAction.types'
 
-const MAGIC_AUTO_SIGN_FEATURE = 'magic-auto-sign'
-
 const mapState = (state: RootStateOrAny): MapStateProps => ({
   isMagicAutoSignEnabled: getIsFeatureEnabled(
     state,
     ApplicationName.DAPPS,
-    MAGIC_AUTO_SIGN_FEATURE
+    FeatureName.MAGIC_AUTO_SIGN
   ),
   authorizationError: getAuthorizationFlowError(state),
   authorizerWallet: getWallet(state),
@@ -199,7 +197,11 @@ export default function withAuthorizedAction<
               return
             }
 
-            if (isMagicAutoSignEnabled && isUserLoggedInWithMagic) {
+            if (
+              isMagicAutoSignEnabled &&
+              isUserLoggedInWithMagic &&
+              !authorizeOptions.manual
+            ) {
               handleGrant(authorization, {
                 requiredAllowance: BigNumber.from(requiredAllowanceInWei),
                 currentAllowance: currentAllowance,
@@ -240,7 +242,11 @@ export default function withAuthorizedAction<
 
             const { targetContractLabel } = authorizeOptions
 
-            if (isMagicAutoSignEnabled && isUserLoggedInWithMagic) {
+            if (
+              isMagicAutoSignEnabled &&
+              isUserLoggedInWithMagic &&
+              !authorizeOptions.manual
+            ) {
               handleGrant(authorization, {
                 onAuthorized: () => onAuthorized(false)
               })
@@ -277,7 +283,11 @@ export default function withAuthorizedAction<
               return
             }
 
-            if (isMagicAutoSignEnabled && isUserLoggedInWithMagic) {
+            if (
+              isMagicAutoSignEnabled &&
+              isUserLoggedInWithMagic &&
+              !authorizeOptions.manual
+            ) {
               handleGrant(authorization, {
                 onAuthorized: () => onAuthorized(false)
               })

--- a/src/containers/withAuthorizedAction/withAuthorizedAction.types.ts
+++ b/src/containers/withAuthorizedAction/withAuthorizedAction.types.ts
@@ -47,13 +47,16 @@ type MintOptions = AuthorizeBaseOptions & {
   targetContractLabel?: string
 }
 
+type ExtraAuthorizationOptions = {
+  manual?: boolean
+}
+
 export type AuthorizeActionOptions = (
   | ApprovalOptions
   | AllowanceOptions
   | MintOptions
-) & {
-  manual?: boolean
-}
+) &
+  ExtraAuthorizationOptions
 
 type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]

--- a/src/containers/withAuthorizedAction/withAuthorizedAction.types.ts
+++ b/src/containers/withAuthorizedAction/withAuthorizedAction.types.ts
@@ -47,10 +47,13 @@ type MintOptions = AuthorizeBaseOptions & {
   targetContractLabel?: string
 }
 
-export type AuthorizeActionOptions =
+export type AuthorizeActionOptions = (
   | ApprovalOptions
   | AllowanceOptions
   | MintOptions
+) & {
+  manual?: boolean
+}
 
 type RecursivePartial<T> = {
   [P in keyof T]?: T[P] extends (infer U)[]

--- a/src/modules/analytics/utils.ts
+++ b/src/modules/analytics/utils.ts
@@ -1,4 +1,5 @@
 import { AnyAction } from 'redux'
+import { isbot } from 'isbot'
 import { Wallet } from '../wallet/types'
 import {
   AnalyticsAction,
@@ -8,7 +9,6 @@ import {
   AnalyticsWindow,
   TransformPayload
 } from './types'
-import { isbot } from 'isbot'
 
 export const trackedActions: { [key: string]: AnalyticsAction } = {}
 

--- a/src/modules/features/types.ts
+++ b/src/modules/features/types.ts
@@ -46,4 +46,6 @@ export type StateWithFeatures = {
 }
 
 // Make sure that in order to handle these, the client has to fetch ApplicationName.DAPPS feature flags.
-export enum FeatureName {}
+export enum FeatureName {
+  MAGIC_AUTO_SIGN = 'magic-auto-sign'
+}


### PR DESCRIPTION
This PR adds the manual mode to the magic auto sign in authorizations. This will be used to specifically set some actions to use the authorization UI.