### PR TITLE
fix: Contentful client entry and entities fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^2.18.3",
         "decentraland-ui": "^6.13.0",
-        "decentraland-ui2": "^0.12.0",
+        "decentraland-ui2": "^0.12.1",
         "ethers": "^5.7.2",
         "events": "^3.3.0",
         "flat": "^5.0.2",
@@ -8709,9 +8709,9 @@
       }
     },
     "node_modules/decentraland-ui2": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-0.12.0.tgz",
-      "integrity": "sha512-uifZ9ArYeDz495ZJHgFEUTbHEIWcVU1u3SfgdD5Ebsxml2ZFJkFeQKHFw5Iisb894NtVRpI3XffAUQPboVrFgA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-0.12.1.tgz",
+      "integrity": "sha512-vTziNPJX+FXwh9BYAl5onCBXTr3XvjNfOxxVXT7Fo+WAHyC/aQ1h3th3EtgCA35uTFyVX9XLy4jD3XUY3ZrFMw==",
       "dependencies": {
         "@contentful/rich-text-react-renderer": "^16.0.1",
         "@dcl/hooks": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "0.0.0-development",
+  "version": "26.0.0",
   "type": "module",
   "main": "dist/index.js",
   "files": [
@@ -25,7 +25,7 @@
     "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-transactions": "^2.18.3",
     "decentraland-ui": "^6.13.0",
-    "decentraland-ui2": "^0.12.0",
+    "decentraland-ui2": "^0.12.1",
     "ethers": "^5.7.2",
     "events": "^3.3.0",
     "flat": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "decentraland-dapps",
-  "version": "26.0.0",
+  "version": "0.0.0-development",
   "type": "module",
   "main": "dist/index.js",
   "files": [

--- a/src/tests/contentfulMocks.ts
+++ b/src/tests/contentfulMocks.ts
@@ -2,15 +2,12 @@ import {
   ContentfulAsset,
   MarketingAdminFields,
   BannerFields,
-  SysLink,
-  ContentfulEntry
+  ContentfulEntry,
+  CampaignFields
 } from '@dcl/schemas'
 import {
   MarketingAdminFieldsWithoutLocales,
-  ContentfulContentWithoutLocales,
-  ContentfulEntryWithoutLocales,
-  ContentfulAssetWithoutLocales,
-  BannerFieldsWithoutLocales
+  ContentfulContentWithoutLocales
 } from '../modules/campaign/ContentfulClient.types'
 
 const mockAdminEntryEn: ContentfulContentWithoutLocales<
@@ -90,7 +87,7 @@ const mockAdminEntryEn: ContentfulContentWithoutLocales<
   }
 }
 
-const mockAdminEntry: ContentfulEntryWithoutLocales<MarketingAdminFields> = {
+const mockAdminEntry: ContentfulEntry<MarketingAdminFields> = {
   metadata: {
     tags: [],
     concepts: []
@@ -176,7 +173,7 @@ const mockAdminEntry: ContentfulEntryWithoutLocales<MarketingAdminFields> = {
   }
 }
 
-const mockCampaignEntry = {
+const mockCampaignEntry: ContentfulEntry<CampaignFields> = {
   metadata: {
     tags: [],
     concepts: []
@@ -230,104 +227,7 @@ const mockCampaignEntry = {
   }
 }
 
-const mockHomepageBannerEntryEn: ContentfulEntryWithoutLocales<BannerFieldsWithoutLocales> = {
-  metadata: {
-    tags: [],
-    concepts: []
-  },
-  sys: {
-    space: {
-      sys: {
-        type: 'Link',
-        linkType: 'Space',
-        id: 'ea2ybdmmn1kv'
-      }
-    },
-    id: '2wT4mlAKsjJ5IZmbBHObgV',
-    type: 'Entry',
-    createdAt: '2025-02-20T15:56:44.523Z',
-    updatedAt: '2025-02-24T17:29:17.938Z',
-    environment: {
-      sys: {
-        id: 'master',
-        type: 'Link',
-        linkType: 'Environment'
-      }
-    },
-    publishedVersion: 23,
-    revision: 4,
-    contentType: {
-      sys: {
-        type: 'Link',
-        linkType: 'ContentType',
-        id: 'banner'
-      }
-    }
-  },
-  fields: {
-    desktopTitle: 'Get ready to publish your wearables with the MFV tag!',
-    desktopTitleAlignment: 'Left',
-    mobileTitle: 'Create for Decentraland Music Festival!',
-    mobileTitleAlignment: 'Left',
-    desktopText: {
-      data: {},
-      content: [
-        {
-          data: {},
-          content: [
-            {
-              data: {},
-              marks: [],
-              value:
-                "Add the MVF tag for your space-themed Wearables and Emotes and they'll be featured in a special Festival Tab on the Marketplace!",
-              nodeType: 'text'
-            }
-          ],
-          nodeType: 'paragraph'
-        }
-      ]
-    },
-    desktopTextAlignment: 'Left',
-    mobileText: {
-      data: {},
-      content: [
-        {
-          data: {},
-          content: [
-            {
-              data: {},
-              marks: [],
-              value:
-                '¡Agrega la etiqueta MVF a tus wearables y emoticones con temática espacial y aparecerán en una pestaña especial del Festival en el Marketplace!',
-              nodeType: 'text'
-            }
-          ],
-          nodeType: 'paragraph'
-        }
-      ]
-    },
-    mobileTextAlignment: 'Left',
-    showButton: false,
-    desktopButtonAlignment: 'Left',
-    mobileButtonAlignment: 'Center',
-    fullSizeBackground: {
-      sys: {
-        type: 'Link',
-        linkType: 'Asset',
-        id: '5XKf4HY4MRWv2fzZD8lXoK'
-      }
-    },
-    mobileBackground: {
-      sys: {
-        type: 'Link',
-        linkType: 'Asset',
-        id: '5YhMhFL4mjaGvFryUCET2b'
-      }
-    }
-  }
-}
-
-const mockHomepageBannerEntry: ContentfulEntryWithoutLocales<BannerFields> = {
+const mockHomepageBannerEntry: ContentfulEntry<BannerFields> = {
   metadata: {
     tags: [],
     concepts: []


### PR DESCRIPTION
This PR includes two fixes that make the campaign sagas work correctly:
- It changes the way we were building the entry with all locales to ignore the language when getting the value, as it does not come wrapped into a language, re-does the loop logic so we don't ignore fields that are set in the EN language but are set in other languages (not necessary but to make it a bit more generic) and includes the complete sys and metadata from the entry that will be used later to get if the entry is a banner.
- Changes the way we're fetching entries from fields to include the complete sys and metadata objects returned by `fetchEntryAllLocales`.