### PR TITLE
feat: Add feature flag to fetch dynamic launcher links for Navbar's Download button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^2.22.0",
         "decentraland-ui": "^6.13.0",
-        "decentraland-ui2": "^0.21.0",
+        "decentraland-ui2": "^0.22.0",
         "ethers": "^5.7.2",
         "events": "^3.3.0",
         "flat": "^5.0.2",
@@ -8709,9 +8709,10 @@
       }
     },
     "node_modules/decentraland-ui2": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-0.21.0.tgz",
-      "integrity": "sha512-nMkecN1tICa6y09Os7Z0WIBJYRC+nreeX62NN9zjzvQGp3pJiUNCWD6kSvcIkwHQWew3VFhrQ++VNq3f4ywblQ==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-0.22.0.tgz",
+      "integrity": "sha512-dtm/5XMlPlf/H48niy3aUE+jy9YI8MEG9JEwqWgQ/WH7i9HWcfur6JJEsqkrbNXHdMMAEsNq18fGfiHXtiCYpg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@contentful/rich-text-react-renderer": "^16.0.1",
         "@dcl/hooks": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-transactions": "^2.22.0",
     "decentraland-ui": "^6.13.0",
-    "decentraland-ui2": "^0.21.0",
+    "decentraland-ui2": "^0.22.0",
     "ethers": "^5.7.2",
     "events": "^3.3.0",
     "flat": "^5.0.2",

--- a/src/containers/Navbar/Navbar.types.tsx
+++ b/src/containers/Navbar/Navbar.types.tsx
@@ -57,7 +57,7 @@ export type MapStateProps = Pick<
   | 'locale'
   | 'walletError'
 > &
-  Pick<NavbarProps2, 'credits'>
+  Pick<NavbarProps2, 'credits' | 'cdnLinks'>
 
 export type MapDispatchProps = Pick<
   NavbarProps,

--- a/src/containers/Navbar/Navbar2.container.tsx
+++ b/src/containers/Navbar/Navbar2.container.tsx
@@ -18,6 +18,7 @@ import {
   switchNetworkRequest
 } from '../../modules/wallet/actions'
 import { getCredits } from '../../modules/credits/selectors'
+import { getLauncherLinksVariant } from '../../modules/features/selectors'
 import { RootDispatch } from '../../types'
 import { NavbarProps2, MapStateProps, MapDispatchProps } from './Navbar.types'
 import Navbar2 from './Navbar2'
@@ -37,7 +38,8 @@ const mapState = (state: any): MapStateProps => {
     isSigningIn: isConnecting(state),
     appChainId: getAppChainId(state),
     isSwitchingNetwork: isSwitchingNetwork(state),
-    walletError: getWalletError(state)
+    walletError: getWalletError(state),
+    cdnLinks: getLauncherLinksVariant(state)
   }
 }
 

--- a/src/containers/Navbar/Navbar2.tsx
+++ b/src/containers/Navbar/Navbar2.tsx
@@ -37,6 +37,7 @@ const Navbar2: React.FC<NavbarProps2> = ({
   docsUrl = 'https://docs.decentraland.org',
   enablePartialSupportAlert = true,
   walletError,
+  cdnLinks,
   ...props
 }: NavbarProps2) => {
   const expectedChainName = getChainName(appChainId)
@@ -183,6 +184,7 @@ const Navbar2: React.FC<NavbarProps2> = ({
                     }
                   : undefined
               }
+              cdnLinks={cdnLinks}
               onClickBalance={handleClickBalance}
               onClickNavbarItem={handleClickNavbarItem}
               onClickUserMenuItem={handleClickUserMenuItem}

--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -170,3 +170,29 @@ export const isCreditsFeatureEnabled = (
 
   return walletsAllowed.includes(address.toLowerCase())
 }
+
+export const getIsLauncherLinksFeatureEnabled = (state: StateWithFeatures) => {
+  const isLauncherLinksEnabled = getIsFeatureEnabled(
+    state,
+    ApplicationName.DAPPS,
+    FeatureName.LAUNCHER_LINKS
+  )
+
+  return isLauncherLinksEnabled
+}
+
+export const getLauncherLinksVariant = (state: StateWithFeatures) => {
+  if (!getIsLauncherLinksFeatureEnabled(state)) {
+    return undefined
+  }
+
+  const launcherLinks = getFeatureVariant(
+    state,
+    ApplicationName.DAPPS,
+    FeatureName.LAUNCHER_LINKS
+  )
+
+  return launcherLinks?.payload?.value
+    ? JSON.parse(launcherLinks.payload.value)
+    : undefined
+}

--- a/src/modules/features/types.ts
+++ b/src/modules/features/types.ts
@@ -49,5 +49,6 @@ export type StateWithFeatures = {
 export enum FeatureName {
   MAGIC_AUTO_SIGN = 'magic-auto-sign',
   CREDITS = 'credits',
-  USER_WALLETS = 'alfa-marketplace-credits'
+  USER_WALLETS = 'alfa-marketplace-credits',
+  LAUNCHER_LINKS = 'launcher-links'
 }


### PR DESCRIPTION
This PR introduces a new feature flag (`launcherLinks`) that enables fetching dynamic launcher download links. These links will be used in the Navbar's "Download" button, allowing the client to update download targets without requiring code changes.
