### PR TITLE
fix: Parsing FF JSON variant

### DIFF
--- a/src/modules/features/selectors.ts
+++ b/src/modules/features/selectors.ts
@@ -192,7 +192,12 @@ export const getLauncherLinksVariant = (state: StateWithFeatures) => {
     FeatureName.LAUNCHER_LINKS
   )
 
-  return launcherLinks?.payload?.value
-    ? JSON.parse(launcherLinks.payload.value)
-    : undefined
+  try {
+    return launcherLinks?.payload?.value
+      ? JSON.parse(launcherLinks.payload.value)
+      : undefined
+  } catch (error) {
+    console.error('Error parsing launcher links', error)
+    return undefined
+  }
 }


### PR DESCRIPTION
This PR fixes the JSON parsing for the FF launcher-links variants