### PR TITLE
feat: Update DCL transactions to use the credits manager amoy contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "dcl-catalyst-client": "^21.1.0",
         "decentraland-connect": "^9.1.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-transactions": "^2.22.0",
+        "decentraland-transactions": "^2.23.0",
         "decentraland-ui": "^6.22.0",
         "decentraland-ui2": "^0.28.1",
         "ethers": "^5.7.2",
@@ -8711,9 +8711,9 @@
       }
     },
     "node_modules/decentraland-transactions": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-2.22.0.tgz",
-      "integrity": "sha512-14gAVmgH2I20uGT5wbLB85D408Em74ckBPkzzPwVm5rJRVYksA3EItdUcRDaEOS8W3JuL3zEUki+kF6iDHPkgw==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-2.23.0.tgz",
+      "integrity": "sha512-1FGXbyx1ulQv87KemhdH9oSR3Vn1L1/qSky4rgASdBodYRXSvba33zT2CZnFePwSVj8LeiF7djbeOGHjnYYinA==",
       "dependencies": {
         "@0xsquid/sdk": "^2.8.25",
         "@0xsquid/squid-types": "^0.1.78",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dcl-catalyst-client": "^21.1.0",
     "decentraland-connect": "^9.1.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-transactions": "^2.22.0",
+    "decentraland-transactions": "^2.23.0",
     "decentraland-ui": "^6.22.0",
     "decentraland-ui2": "^0.28.1",
     "ethers": "^5.7.2",


### PR DESCRIPTION
This PR updates the `decentraland-transactions` dependency which contains a newer version of the credits manager for Amoy which matches the one in production.