### PR TITLE
fix: Get correct contract name from trade when cancelling

### DIFF
--- a/src/modules/trades/TradeService.ts
+++ b/src/modules/trades/TradeService.ts
@@ -1,10 +1,6 @@
 import { Trade, TradeCreation } from '@dcl/schemas'
 import { AuthIdentity } from 'decentraland-crypto-fetch'
-import {
-  ContractName,
-  getContract,
-  getContractName
-} from 'decentraland-transactions'
+import { getContract, getContractName } from 'decentraland-transactions'
 import { TradesAPI } from './api'
 import { getOnChainTrade } from '../../lib/trades'
 import { sendTransaction } from '../wallet/utils'


### PR DESCRIPTION
This PR fixes an issue where the `trade.contract` was used as the contract name when cancelling a trade.