### PR TITLE
fix: Transak order data API changes

### DIFF
--- a/src/modules/gateway/transak/Transak.ts
+++ b/src/modules/gateway/transak/Transak.ts
@@ -52,11 +52,11 @@ export class Transak {
           WebSocketEvents.ORDER_FAILED
         ]
 
-        const channel = this.pusher.subscribe(orderData.status.id)
-        this.emitPurchaseEvent(orderData.status, network)
+        const channel = this.pusher.subscribe(orderData.id)
+        this.emitPurchaseEvent(orderData, network)
 
         events.forEach(event => {
-          channel.bind(event, (orderData: OrderData['status']) => {
+          channel.bind(event, (orderData: OrderData) => {
             this.emitPurchaseEvent(orderData, network)
             if (
               [
@@ -124,10 +124,7 @@ export class Transak {
    * @param orderData - Order entity that comes from the Transak SDK.
    * @param status - Status of the order.
    */
-  private createPurchase(
-    orderData: OrderData['status'],
-    network: Network
-  ): Purchase {
+  private createPurchase(orderData: OrderData, network: Network): Purchase {
     const {
       id,
       cryptoAmount,
@@ -175,7 +172,7 @@ export class Transak {
    * @param status - Status of the order.
    * @param Network - Network in which the transaction will be done.
    */
-  emitPurchaseEvent(orderData: OrderData['status'], network: Network) {
+  emitPurchaseEvent(orderData: OrderData, network: Network) {
     purchaseEventsChannel.put({
       type: PURCHASE_EVENT,
       purchase: this.createPurchase(orderData, network)

--- a/src/modules/gateway/transak/types.ts
+++ b/src/modules/gateway/transak/types.ts
@@ -55,46 +55,43 @@ export type CustomizationOptions = {
 }
 
 export type OrderData = {
-  eventName: string
-  status: {
-    id: string
-    autoExpiresAt: string
-    conversionPrice: number
-    convertedFiatAmount: number
-    convertedFiatCurrency: string
-    createdAt: string
-    cryptoAmount: number
-    cryptoCurrency: string
-    cryptocurrency: string
-    envName: string
-    fiatAmount: number
-    fiatCurrency: string
-    fromWalletAddress: string
-    isBuyOrSell: 'BUY' | 'SELL'
-    isNFTOrder: boolean
-    transactionLink?: string
-    transactionHash?: string
-    network: 'ethereum' | 'matic'
-    nftAssetInfo?: {
-      collection: string
-      tokenId: string[]
-    }
-    paymentOptionId: string
-    quoteId: string
-    referenceCode: number
-    reservationId: string
-    status: TransakOrderStatus
-    totalFeeInFiat: number
-    walletAddress: string
-    walletLink: string
+  id: string
+  autoExpiresAt: string
+  conversionPrice: number
+  convertedFiatAmount: number
+  convertedFiatCurrency: string
+  createdAt: string
+  cryptoAmount: number
+  cryptoCurrency: string
+  cryptocurrency: string
+  envName: string
+  fiatAmount: number
+  fiatCurrency: string
+  fromWalletAddress: string
+  isBuyOrSell: 'BUY' | 'SELL'
+  isNFTOrder: boolean
+  transactionLink?: string
+  transactionHash?: string
+  network: 'ethereum' | 'matic'
+  nftAssetInfo?: {
+    collection: string
+    tokenId: string[]
   }
+  paymentOptionId: string
+  quoteId: string
+  referenceCode: number
+  reservationId: string
+  status: TransakOrderStatus
+  totalFeeInFiat: number
+  walletAddress: string
+  walletLink: string
 }
 
 export type OrderResponse = {
   meta: {
     orderId: string
   }
-  data: Pick<OrderData['status'], 'id' | 'status' | 'transactionHash'> & {
+  data: Pick<OrderData, 'id' | 'status' | 'transactionHash'> & {
     errorMessage: string | null
   }
 }


### PR DESCRIPTION
The `TransakSDK.EVENTS.TRANSAK_ORDER_CREATED` is now receiving the `orderData` directly instead of being in the `status` property. This PR changes this to make the flow work again.

Closes https://github.com/decentraland/core-team/issues/36