### PR TITLE
feat: credits client signed fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "decentraland-crypto-fetch": "^2.0.1",
         "decentraland-transactions": "^2.24.1",
         "events": "^3.3.0",
+        "eventsource": "^3.0.7",
         "flat": "^5.0.2",
         "isbot": "^5.1.22",
         "pusher-js": "^8.0.1",
@@ -10755,6 +10756,27 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/evp_bytestokey": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "decentraland-crypto-fetch": "^2.0.1",
     "decentraland-transactions": "^2.24.1",
     "events": "^3.3.0",
+    "eventsource": "^3.0.7",
     "flat": "^5.0.2",
     "isbot": "^5.1.22",
     "pusher-js": "^8.0.1",

--- a/src/modules/credits/CreditsClient.ts
+++ b/src/modules/credits/CreditsClient.ts
@@ -1,3 +1,4 @@
+import { EventSource } from 'eventsource'
 import { ChainId } from '@dcl/schemas/dist/dapps/chain-id'
 import { BaseClient, BaseClientConfig } from '../../lib'
 import {
@@ -83,7 +84,10 @@ export class CreditsClient extends BaseClient {
       }
 
       eventSource = new EventSource(
-        `${this.url}/users/${address}/credits/stream`
+        `${this.url}/users/${address}/credits/stream`,
+        {
+          fetch: this.rawFetch.bind(this)
+        }
       )
 
       eventSource.onopen = () => {


### PR DESCRIPTION
Closes https://github.com/decentraland/core-team/issues/89

This pull request introduces support for using a custom fetch implementation with server-sent events in the `CreditsClient` module. This allows the usage of custom headers for signed fetch requests in the EventSource initialization.

**Dependency management:**
- Added the `eventsource` package to `package.json` to support the usage of headers in server-sent events.