### PR TITLE
fix: sign the sign-external-call credits request with the user identity

### DIFF
--- a/src/lib/credits.spec.ts
+++ b/src/lib/credits.spec.ts
@@ -8,10 +8,21 @@ import { getOnChainTrade } from './trades'
 // Only mock external dependencies
 const mockSendTransaction = jest.fn()
 const mockGetOnChainTrade = jest.fn()
+const mockSignedFetch = jest.fn()
+const mockGetIdentity = jest.fn()
 
 // Mock wallet utils
 jest.mock('../modules/wallet/utils', () => ({
   sendTransaction: (...args) => mockSendTransaction(...args)
+}))
+
+// Mock signed fetch and identity used by the credits server signing call
+jest.mock('decentraland-crypto-fetch', () => ({
+  signedFetchFactory: () => mockSignedFetch
+}))
+
+jest.mock('@dcl/single-sign-on-client', () => ({
+  localStorageGetIdentity: (...args: unknown[]) => mockGetIdentity(...args)
 }))
 
 // Mock trades utils
@@ -738,24 +749,14 @@ describe('CreditsService', () => {
   })
 
   describe('useCreditsCollectionManager', () => {
-    let mockFetch: jest.Mock
-    let originalFetch: typeof global.fetch
-
     beforeEach(() => {
-      originalFetch = global.fetch
-      mockFetch = jest.fn()
-      global.fetch = mockFetch
-
-      mockFetch.mockResolvedValue({
+      mockGetIdentity.mockReturnValue({ authChain: [], ephemeralIdentity: {}, expiration: new Date() } as any)
+      mockSignedFetch.mockResolvedValue({
         ok: true,
         json: jest.fn().mockResolvedValue({
           signature: '0xcustomSignature'
         })
       } as any)
-    })
-
-    afterEach(() => {
-      global.fetch = originalFetch
     })
 
     describe('when signing the external call', () => {
@@ -804,14 +805,15 @@ describe('CreditsService', () => {
           creditsServerUrl
         )
 
-        expect(mockFetch).toHaveBeenCalledWith(
+        expect(mockSignedFetch).toHaveBeenCalledWith(
           `${creditsServerUrl}/sign-external-call`,
           expect.objectContaining({
             method: 'POST',
             headers: {
               'Content-Type': 'application/json'
             },
-            body: expect.stringContaining(walletAddress)
+            body: expect.stringContaining(walletAddress),
+            identity: expect.anything()
           })
         )
       })
@@ -838,7 +840,8 @@ describe('CreditsService', () => {
 
     describe('and the signature request fails', () => {
       beforeEach(() => {
-        mockFetch.mockResolvedValue({
+        mockGetIdentity.mockReturnValue({ authChain: [], ephemeralIdentity: {}, expiration: new Date() } as any)
+        mockSignedFetch.mockResolvedValue({
           ok: false,
           json: jest.fn().mockResolvedValue({
             error: 'Signature failed'
@@ -878,6 +881,47 @@ describe('CreditsService', () => {
             'https://credits-server.com'
           )
         ).rejects.toThrow('Failed to get external call signature')
+      })
+    })
+
+    describe('and there is no identity for the wallet', () => {
+      beforeEach(() => {
+        mockGetIdentity.mockReturnValue(null)
+      })
+
+      it('should throw an error and not call the credits server', async () => {
+        await expect(
+          creditsService.useCreditsCollectionManager(
+            '0xuser',
+            [
+              {
+                id: 'credit1',
+                amount: '100',
+                expiresAt: '1234567890',
+                signature: '0xsignature1',
+                availableAmount: '100',
+                contract: getContract(ContractName.CreditsManager, ChainId.MATIC_AMOY).address,
+                season: 1,
+                timestamp: '1234567890',
+                userAddress: '0xuser'
+              }
+            ],
+            ChainId.MATIC_AMOY,
+            [
+              '0x0000000000000000000000000000000000000001',
+              '0x0000000000000000000000000000000000000002',
+              ethers.utils.hexZeroPad('0x123', 32),
+              'Name',
+              'SYM',
+              'uri',
+              '0x0000000000000000000000000000000000000003',
+              []
+            ],
+            '1000',
+            'https://credits-server.com'
+          )
+        ).rejects.toThrow('Could not find an identity')
+        expect(mockSignedFetch).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/lib/credits.ts
+++ b/src/lib/credits.ts
@@ -9,6 +9,13 @@ import { Credit } from '../modules/credits/types'
 import { sendTransaction } from '../modules/wallet/utils'
 import { getOnChainTrade } from './trades'
 
+// Instantiate the signed-fetch helper once (lazily); the factory is stateless.
+let signedFetch: ReturnType<typeof signedFetchFactory> | null = null
+function getSignedFetch() {
+  if (!signedFetch) signedFetch = signedFetchFactory()
+  return signedFetch
+}
+
 export type CreditsData = {
   value: string
   expiresAt: number
@@ -488,8 +495,7 @@ export class CreditsService {
       throw new Error(`Could not find an identity for ${walletAddress} to sign the external call request`)
     }
 
-    const signedFetch = signedFetchFactory()
-    const signatureResponse = await signedFetch(`${creditsServerUrl}/sign-external-call`, {
+    const signatureResponse = await getSignedFetch()(`${creditsServerUrl}/sign-external-call`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'

--- a/src/lib/credits.ts
+++ b/src/lib/credits.ts
@@ -2,6 +2,8 @@ import { Interface, defaultAbiCoder } from '@ethersproject/abi'
 import { hexZeroPad, hexlify } from '@ethersproject/bytes'
 import { randomBytes } from '@ethersproject/random'
 import { ChainId, Item, NFT, Network, Order, Trade, TradeAssetType } from '@dcl/schemas'
+import { localStorageGetIdentity } from '@dcl/single-sign-on-client'
+import { signedFetchFactory } from 'decentraland-crypto-fetch'
 import { ContractData, ContractName, getContract, getContractName } from 'decentraland-transactions'
 import { Credit } from '../modules/credits/types'
 import { sendTransaction } from '../modules/wallet/utils'
@@ -478,7 +480,16 @@ export class CreditsService {
     const { contract, creditsData, creditsSignatures, externalCall, maxUncreditedValue, maxCreditedValue } =
       this.prepareCreditsCollectionManager(credits, chainId, collectionManagerArgs, totalPrice)
 
-    const signatureResponse = await fetch(`${creditsServerUrl}/sign-external-call`, {
+    // The credits server requires an ADR-44 signed-fetch request and binds the
+    // signature to the authenticated wallet, so this call must be signed with
+    // the user's identity rather than sent as a plain fetch.
+    const identity = localStorageGetIdentity(walletAddress)
+    if (!identity) {
+      throw new Error(`Could not find an identity for ${walletAddress} to sign the external call request`)
+    }
+
+    const signedFetch = signedFetchFactory()
+    const signatureResponse = await signedFetch(`${creditsServerUrl}/sign-external-call`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -488,7 +499,8 @@ export class CreditsService {
         chainId: chainId,
         creditsManagerAddress: contract.address,
         externalCall: externalCall
-      })
+      }),
+      identity
     })
 
     if (!signatureResponse.ok) {


### PR DESCRIPTION
## What

`CreditsService.useCreditsCollectionManager` called `${creditsServerUrl}/sign-external-call` with a plain `fetch` and no authentication headers. That endpoint requires an ADR-44 signed-fetch request and binds the signature to the authenticated wallet, so the plain call would be rejected.

## Change

Sign the request with the user's identity:
- Resolve the identity via `localStorageGetIdentity(walletAddress)` (same source as the identity sagas) and throw a clear error if it is missing.
- Send the request through `signedFetchFactory()` with `{ ..., identity }`, matching the `BaseClient` signed-fetch pattern.

## Verification

- `tsc --noEmit` clean.
- eslint clean on the changed lines (a pre-existing prettier finding at credits.ts:345 is unrelated and left untouched).
- `credits.spec.ts`: 22 passing — updated the `useCreditsCollectionManager` suite to mock `signedFetchFactory`/`localStorageGetIdentity`, asserts the request is signed, and added a case that throws when no identity is available.