### PR TITLE
chore: revert signed-fetch on sign-external-call credits request

### DIFF
--- a/src/lib/credits.spec.ts
+++ b/src/lib/credits.spec.ts
@@ -8,21 +8,10 @@ import { getOnChainTrade } from './trades'
 // Only mock external dependencies
 const mockSendTransaction = jest.fn()
 const mockGetOnChainTrade = jest.fn()
-const mockSignedFetch = jest.fn()
-const mockGetIdentity = jest.fn()
 
 // Mock wallet utils
 jest.mock('../modules/wallet/utils', () => ({
   sendTransaction: (...args) => mockSendTransaction(...args)
-}))
-
-// Mock signed fetch and identity used by the credits server signing call
-jest.mock('decentraland-crypto-fetch', () => ({
-  signedFetchFactory: () => mockSignedFetch
-}))
-
-jest.mock('@dcl/single-sign-on-client', () => ({
-  localStorageGetIdentity: (...args: unknown[]) => mockGetIdentity(...args)
 }))
 
 // Mock trades utils
@@ -749,14 +738,24 @@ describe('CreditsService', () => {
   })
 
   describe('useCreditsCollectionManager', () => {
+    let mockFetch: jest.Mock
+    let originalFetch: typeof global.fetch
+
     beforeEach(() => {
-      mockGetIdentity.mockReturnValue({ authChain: [], ephemeralIdentity: {}, expiration: new Date() } as any)
-      mockSignedFetch.mockResolvedValue({
+      originalFetch = global.fetch
+      mockFetch = jest.fn()
+      global.fetch = mockFetch
+
+      mockFetch.mockResolvedValue({
         ok: true,
         json: jest.fn().mockResolvedValue({
           signature: '0xcustomSignature'
         })
       } as any)
+    })
+
+    afterEach(() => {
+      global.fetch = originalFetch
     })
 
     describe('when signing the external call', () => {
@@ -805,15 +804,14 @@ describe('CreditsService', () => {
           creditsServerUrl
         )
 
-        expect(mockSignedFetch).toHaveBeenCalledWith(
+        expect(mockFetch).toHaveBeenCalledWith(
           `${creditsServerUrl}/sign-external-call`,
           expect.objectContaining({
             method: 'POST',
             headers: {
               'Content-Type': 'application/json'
             },
-            body: expect.stringContaining(walletAddress),
-            identity: expect.anything()
+            body: expect.stringContaining(walletAddress)
           })
         )
       })
@@ -840,8 +838,7 @@ describe('CreditsService', () => {
 
     describe('and the signature request fails', () => {
       beforeEach(() => {
-        mockGetIdentity.mockReturnValue({ authChain: [], ephemeralIdentity: {}, expiration: new Date() } as any)
-        mockSignedFetch.mockResolvedValue({
+        mockFetch.mockResolvedValue({
           ok: false,
           json: jest.fn().mockResolvedValue({
             error: 'Signature failed'
@@ -881,47 +878,6 @@ describe('CreditsService', () => {
             'https://credits-server.com'
           )
         ).rejects.toThrow('Failed to get external call signature')
-      })
-    })
-
-    describe('and there is no identity for the wallet', () => {
-      beforeEach(() => {
-        mockGetIdentity.mockReturnValue(null)
-      })
-
-      it('should throw an error and not call the credits server', async () => {
-        await expect(
-          creditsService.useCreditsCollectionManager(
-            '0xuser',
-            [
-              {
-                id: 'credit1',
-                amount: '100',
-                expiresAt: '1234567890',
-                signature: '0xsignature1',
-                availableAmount: '100',
-                contract: getContract(ContractName.CreditsManager, ChainId.MATIC_AMOY).address,
-                season: 1,
-                timestamp: '1234567890',
-                userAddress: '0xuser'
-              }
-            ],
-            ChainId.MATIC_AMOY,
-            [
-              '0x0000000000000000000000000000000000000001',
-              '0x0000000000000000000000000000000000000002',
-              ethers.utils.hexZeroPad('0x123', 32),
-              'Name',
-              'SYM',
-              'uri',
-              '0x0000000000000000000000000000000000000003',
-              []
-            ],
-            '1000',
-            'https://credits-server.com'
-          )
-        ).rejects.toThrow('Could not find an identity')
-        expect(mockSignedFetch).not.toHaveBeenCalled()
       })
     })
   })

--- a/src/lib/credits.ts
+++ b/src/lib/credits.ts
@@ -2,19 +2,10 @@ import { Interface, defaultAbiCoder } from '@ethersproject/abi'
 import { hexZeroPad, hexlify } from '@ethersproject/bytes'
 import { randomBytes } from '@ethersproject/random'
 import { ChainId, Item, NFT, Network, Order, Trade, TradeAssetType } from '@dcl/schemas'
-import { localStorageGetIdentity } from '@dcl/single-sign-on-client'
-import { signedFetchFactory } from 'decentraland-crypto-fetch'
 import { ContractData, ContractName, getContract, getContractName } from 'decentraland-transactions'
 import { Credit } from '../modules/credits/types'
 import { sendTransaction } from '../modules/wallet/utils'
 import { getOnChainTrade } from './trades'
-
-// Instantiate the signed-fetch helper once (lazily); the factory is stateless.
-let signedFetch: ReturnType<typeof signedFetchFactory> | null = null
-function getSignedFetch() {
-  if (!signedFetch) signedFetch = signedFetchFactory()
-  return signedFetch
-}
 
 export type CreditsData = {
   value: string
@@ -487,15 +478,7 @@ export class CreditsService {
     const { contract, creditsData, creditsSignatures, externalCall, maxUncreditedValue, maxCreditedValue } =
       this.prepareCreditsCollectionManager(credits, chainId, collectionManagerArgs, totalPrice)
 
-    // The credits server requires an ADR-44 signed-fetch request and binds the
-    // signature to the authenticated wallet, so this call must be signed with
-    // the user's identity rather than sent as a plain fetch.
-    const identity = localStorageGetIdentity(walletAddress)
-    if (!identity) {
-      throw new Error(`Could not find an identity for ${walletAddress} to sign the external call request`)
-    }
-
-    const signatureResponse = await getSignedFetch()(`${creditsServerUrl}/sign-external-call`, {
+    const signatureResponse = await fetch(`${creditsServerUrl}/sign-external-call`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json'
@@ -505,8 +488,7 @@ export class CreditsService {
         chainId: chainId,
         creditsManagerAddress: contract.address,
         externalCall: externalCall
-      }),
-      identity
+      })
     })
 
     if (!signatureResponse.ok) {


### PR DESCRIPTION
Reverts the change that routed the credits `/sign-external-call` request through ADR-44 signed-fetch and required a local SSO identity.

Review concluded the endpoint is safe without client-side signing: on-chain `useCredits` validates each credit against a platform-issued signature bound to the credit owner, so a caller can only ever spend their own credits — requesting a signature for another `userAddress` gains nothing. Requiring signed-fetch on the client therefore added a precondition (it threw when no SSO identity was present locally) for no security benefit, and would only matter if the server enforced auth on that endpoint, which it does not.

This restores the prior plain-`fetch` behavior. The signing change was never published, so there is no released impact.

Verified: `npm run build` (tsc) clean; `src/lib/credits.spec.ts` 21/21 passing.