### PR TITLE
feat: publish a stable release on github release events

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -1,6 +1,9 @@
 name: build-test-publish
 
-on: [push]
+on:
+  push:
+  release:
+    types: [created]
 
 jobs:
   build-test-publish:
@@ -22,7 +25,7 @@ jobs:
       - name: Test
         run: npm test
       - name: Publish
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || github.event_name == 'release'
         uses: decentraland/oddish-action@0074f2d535c43b5c83f136525304a6277166d77f
         with:
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## what

make the publish workflow cut a **stable `latest`** release when a GitHub Release is created, instead of only ever publishing `next` snapshots.

## why

`build-test-publish.yml` only triggers `on: [push]`, and `oddish-action` on a master push publishes a snapshot version (`X.Y.Z-<timestamp>.commit-<sha>`) under the **`next`** dist-tag. After the migration from semantic-release to `oddish-action` (#803) there is no trigger that publishes a stable `latest`, so merges to master (e.g. the node-fetch/axios change in #807) only produced `*-commit-<sha>` snapshots and `latest` stayed at `28.9.0`.

`decentraland-connect` already does this correctly — its workflow triggers on `release: created`, which is what lets `oddish-action` publish the clean semver to `latest`.

## changes

- add a `release: { types: [created] }` trigger to `build-test-publish.yml`
- widen the Publish step condition to `github.ref == 'refs/heads/master' || github.event_name == 'release'` (a release event's ref is the tag, not `refs/heads/master`, so it would otherwise be skipped)

## result

- pushes to master keep publishing `next` snapshots (unchanged)
- creating a GitHub Release publishes the stable version to `latest`

After this merges, cutting a Release will publish the stable build that includes #807, so downstreams (e.g. decentraland-gatsby) can bump to it without pinning a snapshot.
