### PR TITLE
fix: return the amount for usd-pegged trade assets

### DIFF
--- a/src/lib/trades.spec.ts
+++ b/src/lib/trades.spec.ts
@@ -5,6 +5,7 @@ import {
   ERC20TradeAsset,
   ERC721TradeAsset,
   Trade,
+  USDPeggedManaTradeAsset,
   TradeAsset,
   TradeCreation,
   TradeType
@@ -66,6 +67,73 @@ describe('when getting the value for a trade asset', () => {
     it('should return the item id', () => {
       expect(getValueForTradeAsset(asset)).toBe((asset as CollectionItemTradeAsset).itemId)
     })
+  })
+
+  /**
+   * A USD-pegged amount is an amount like any other here. It is denominated in USD wei rather than MANA wei,
+   * but the conversion happens in the contract at settlement — this function only has to reproduce the value
+   * the seller signed.
+   */
+  describe('and the asset is USD-PEGGED MANA', () => {
+    beforeEach(() => {
+      asset = {
+        assetType: TradeAssetType.USD_PEGGED_MANA,
+        contractAddress: '0xmana',
+        amount: '500000000000000000',
+        extra: ''
+      } as USDPeggedManaTradeAsset
+    })
+
+    it('should return the amount, not an empty value', () => {
+      expect(getValueForTradeAsset(asset)).toBe((asset as USDPeggedManaTradeAsset).amount)
+    })
+  })
+})
+
+/**
+ * THE REGRESSION THAT MATTERED, AND WHY IT IS ASSERTED HERE.
+ *
+ * `getOnChainTrade` rebuilds the trade struct that `TradeService.accept` and `TradeService.cancel` hand to the
+ * contract. With no case for `USD_PEGGED_MANA`, the received value came back as `''`, so a USD-pegged listing
+ * could be neither bought nor cancelled by ANY consumer of this package — it surfaced in production as
+ * `invalid BigNumber string (argument="value", value="")` when a creator tried to take their own listing down.
+ *
+ * Asserted against the literal amount rather than through `getValueForTradeAsset`: routing the expectation
+ * through the same function under test is exactly why a green suite did not catch this.
+ */
+describe('when rebuilding a USD-pegged trade for the contract', () => {
+  it('should preserve the amount so the struct still matches the seller signature', () => {
+    const trade = {
+      signer: '0xsigner',
+      signature: '0xsignature',
+      type: TradeType.PUBLIC_NFT_ORDER,
+      network: Network.MATIC,
+      chainId: ChainId.MATIC_AMOY,
+      checks: {
+        expiration: Date.now() + 100000000,
+        effective: Date.now(),
+        uses: 1,
+        salt: '0x',
+        allowedRoot: '0x',
+        contractSignatureIndex: 0,
+        externalChecks: [],
+        signerSignatureIndex: 0
+      },
+      sent: [{ assetType: TradeAssetType.ERC721, contractAddress: '0xcollection', tokenId: '1', extra: '0x' }],
+      received: [
+        {
+          assetType: TradeAssetType.USD_PEGGED_MANA,
+          contractAddress: '0xmana',
+          amount: '500000000000000000',
+          extra: '0x',
+          beneficiary: '0xseller'
+        }
+      ]
+    } as unknown as Trade
+
+    const onChainTrade = getOnChainTrade(trade, '0xbuyer')
+
+    expect(onChainTrade.received[0].value).toBe('500000000000000000')
   })
 })
 

--- a/src/lib/trades.ts
+++ b/src/lib/trades.ts
@@ -63,9 +63,28 @@ export function getValueForTradeAsset(asset: TradeAsset): string {
       return asset.itemId
     case TradeAssetType.ERC20:
       return asset.amount
-    default:
-      console.error('Invalid asset type:', asset)
+    case TradeAssetType.USD_PEGGED_MANA:
+      // The amount VERBATIM, exactly as for ERC20. It is denominated in USD wei rather than MANA wei, but
+      // converting it is the contract's job at settlement — what goes in here has to reproduce the value the
+      // SELLER signed, or the rebuilt trade hashes differently and the signature check rejects it on chain.
+      //
+      // Falling through to `default` returned '' for these, and every consumer of this package inherited it:
+      // `generateTradeValues` feeds this into the EIP-712 struct and `getOnChainTrade` rebuilds that struct for
+      // `accept()` and `cancelSignature()`. So a USD-pegged listing could be neither bought NOR cancelled —
+      // observed in production as `invalid BigNumber string (argument="value", value="")` when a creator tried
+      // to take their own listing down from the Builder.
+      return asset.amount
+    default: {
+      // Compile-time exhaustiveness: `USDPeggedManaTradeAsset` has been a member of the `TradeAsset` union all
+      // along, so the missing case above was a hole in a closed union that `default` silently absorbed. A new
+      // member now becomes a type error here instead of another empty value that only surfaces on chain.
+      //
+      // Runtime behaviour is unchanged on purpose: this also receives API data, so a value outside the union
+      // must degrade rather than throw.
+      const unhandled: never = asset
+      console.error('Invalid asset type:', unhandled)
       return ''
+    }
   }
 }
 


### PR DESCRIPTION
A USD-pegged listing can be **neither bought nor cancelled** by any consumer of this package.

`getValueForTradeAsset` has no case for `TradeAssetType.USD_PEGGED_MANA`, so it falls through to `default`,
logs "Invalid asset type" and returns `''`.

That value is not diagnostic — it is load-bearing. `generateTradeValues` feeds it into the EIP-712 struct, and
`getOnChainTrade` rebuilds that struct for **both** `TradeService.accept` and `TradeService.cancel`:

```
TradeService.cancel(trade, …) → getOnChainTrade → generateTradeValues → getValueForTradeAsset  // '' here
```

So the seller signs a trade whose received value is `500000000000000000`, and the client submits one whose
received value is `''`. Different struct, different trade hash, and the on-chain signature check rejects it.

Observed in production on `.zone`, in the Builder, when a creator tried to take **their own** listing down:

```
Invalid asset type: { assetType: 2, amount: '500000000000000000', … }
  at getValueForTradeAsset → generateTradeValues → getOnChainTrade → cancel

Error when removing order for item
invalid BigNumber string (argument="value", value="", code=INVALID_ARGUMENT, version=bignumber/5.8.0)
```

`USDPeggedManaTradeAsset` has been a member of the exported `TradeAsset` union all along, so this was a missing
case in a **closed union** that `default` silently absorbed.

## Who this affects

Everything that goes through `TradeService`:

| consumer | path | effect |
|---|---|---|
| Builder | `TradeService.cancel` | a creator cannot remove their own pegged listing |
| Marketplace | `TradeService.cancel` | same |
| Marketplace | `TradeService.accept` | a pegged listing cannot be bought |

The marketplace webapp carries its own copy of these helpers, and it was fixed there
(decentraland/marketplace#2670) — but that copy feeds `estimateTradeGas` and trade *creation*, while the accept
and cancel go through **this** package. So that fix did not reach the buy path; this one does.

The shop app sidesteps the gap with its own extractor and a comment pointing at this function.

## The fix

```ts
case TradeAssetType.USD_PEGGED_MANA:
  return asset.amount
```

The amount **verbatim**, exactly as for `ERC20`. It is denominated in USD wei rather than MANA wei, but
converting it is the contract's job at settlement — what goes in here has to reproduce the value the seller
signed.

The `default` branch now also asserts exhaustiveness (`const unhandled: never = asset`), so the next member
added to the `TradeAsset` union becomes a **type error here** instead of another empty value that only surfaces
as a rejected signature on chain. Runtime behaviour is unchanged on purpose: this function also receives API
data, so a value outside the union must still degrade rather than throw.

## Tests

Two, and **both fail without the fix** (verified by removing the case and re-running):

1. A USD-pegged asset returns its amount, not an empty value.
2. `getOnChainTrade` **preserves** that amount when it rebuilds the struct — the accept/cancel path, asserted
   against the literal `500000000000000000` rather than through `getValueForTradeAsset`. The existing
   structural test builds its expectation by calling that same function, which is correct for checking shape
   but is exactly why this reached production with a green suite in three codebases.

```
50 suites / 682 passing · build clean · lint clean · prettier clean
```

## After merge

This needs a **release**, then a version bump in `builder` and `marketplace` before either is actually fixed.
Worth sequencing deliberately: until the bump lands, a creator with a pegged listing still cannot cancel it.