### PR TITLE
feat: allow loading analytics.js from a custom url

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,7 +895,7 @@ const analyticsMiddleware = createAnalyticsMiddleware('SEGMENT WRITE KEY', {
 
 `analytics.js` fetches its settings from the origin of that URL. Pass `cdnUrl` as well when the proxy serves them from a different host.
 
-Both are the origin a third party script is loaded from, so they are meant to be trusted HTTPS URLs that come from the build configuration of the dapp, never from user input.
+Both decide where a third party script is loaded from, so they are meant to be trusted URLs that come from the build configuration of the dapp, never from user input. Values that are not valid URLs, or that are not served over HTTPS unless they belong to the dapp's own origin, are ignored with a warning and the bundle keeps loading from Segment's CDN.
 
 **Saga**:
 

--- a/README.md
+++ b/README.md
@@ -895,6 +895,8 @@ const analyticsMiddleware = createAnalyticsMiddleware('SEGMENT WRITE KEY', {
 
 `analytics.js` fetches its settings from the origin of that URL. Pass `cdnUrl` as well when the proxy serves them from a different host.
 
+Both are the origin a third party script is loaded from, so they are meant to be trusted HTTPS URLs that come from the build configuration of the dapp, never from user input.
+
 **Saga**:
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -885,6 +885,16 @@ const enhancer = composeEnhancers(middleware)
 const store = createStore(rootReducer, enhancer)
 ```
 
+By default `analytics.js` is loaded from Segment's CDN, which ad blockers drop. To load it from a first party proxy instead, pass the URL of the bundle it serves:
+
+```ts
+const analyticsMiddleware = createAnalyticsMiddleware('SEGMENT WRITE KEY', {
+  analyticsUrl: 'https://analytics.example.org/aPath/aBundle.min.js'
+})
+```
+
+`analytics.js` fetches its settings from the origin of that URL. Pass `cdnUrl` as well when the proxy serves them from a different host.
+
 **Saga**:
 
 ```ts

--- a/src/modules/analytics/index.ts
+++ b/src/modules/analytics/index.ts
@@ -1,4 +1,5 @@
 export * from './middleware'
 export * from './sagas'
+export * from './snippet'
 export * from './types'
 export * from './utils'

--- a/src/modules/analytics/middleware.ts
+++ b/src/modules/analytics/middleware.ts
@@ -1,12 +1,12 @@
 import { RootMiddleware } from '../../types'
+import { AnalyticsSnippetOptions, configureAnalyticsSnippet } from './snippet'
 import { getAnalytics, track } from './utils'
-import './snippet'
 
 const disabledMiddleware: RootMiddleware = _ => next => action => {
   next(action)
 }
 
-export function createAnalyticsMiddleware(apiKey: string): RootMiddleware {
+export function createAnalyticsMiddleware(apiKey: string, options?: AnalyticsSnippetOptions): RootMiddleware {
   if (!apiKey) {
     console.warn('Analytics: middleware disabled due to missing API key')
     return disabledMiddleware
@@ -18,6 +18,7 @@ export function createAnalyticsMiddleware(apiKey: string): RootMiddleware {
     return disabledMiddleware
   }
 
+  configureAnalyticsSnippet(options)
   analytics.load(apiKey)
 
   return _ => next => action => {

--- a/src/modules/analytics/snippet.spec.ts
+++ b/src/modules/analytics/snippet.spec.ts
@@ -117,21 +117,62 @@ describe('Analytics Snippet', () => {
     })
   })
 
-  describe('when the snippet is configured with a malformed analytics url', () => {
+  describe.each([
+    ['malformed', 'http://['],
+    ['not served over https', 'http://analytics.example.com/aPath/aBundle.min.js'],
+    ['not http', 'data:text/javascript,console.log(1)']
+  ])('when the snippet is configured with an analytics url that is %s', (_case, analyticsUrl) => {
     let consoleWarn: jest.SpyInstance
 
     beforeEach(() => {
       consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
-      configureAnalyticsSnippet({ analyticsUrl: 'http://[' })
+      configureAnalyticsSnippet({ analyticsUrl })
     })
 
     afterEach(() => {
       consoleWarn.mockRestore()
     })
 
-    it('should warn about it and leave analytics.js resolving the settings on its own', () => {
+    it('should warn about it and ignore it', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
       expect(consoleWarn).toHaveBeenCalled()
+      expect(getInjectedScript()).toHaveProperty('src', `https://cdn.segment.com/analytics.js/v1/${WRITE_KEY}/analytics.min.js`)
       expect(anyWindow.analytics._cdn).toBeUndefined()
+    })
+  })
+
+  describe('when the snippet is configured with an analytics url of the dapp itself', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ analyticsUrl: '/aPath/aBundle.min.js' })
+    })
+
+    it('should load the bundle from it even if the dapp is not served over https', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(getInjectedScript()).toHaveProperty('src', `${window.location.origin}/aPath/aBundle.min.js`)
+      expect(anyWindow.analytics._cdn).toBe(window.location.origin)
+    })
+  })
+
+  describe('when the snippet is configured with a cdn url that is not served over https', () => {
+    let consoleWarn: jest.SpyInstance
+
+    beforeEach(() => {
+      consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      configureAnalyticsSnippet({
+        analyticsUrl: ANALYTICS_URL,
+        cdnUrl: 'http://cdn.example.com'
+      })
+    })
+
+    afterEach(() => {
+      consoleWarn.mockRestore()
+    })
+
+    it('should warn about it and fall back to the origin of the analytics url', () => {
+      expect(consoleWarn).toHaveBeenCalled()
+      expect(anyWindow.analytics._cdn).toBe('https://analytics.example.com')
     })
   })
 

--- a/src/modules/analytics/snippet.spec.ts
+++ b/src/modules/analytics/snippet.spec.ts
@@ -1,0 +1,113 @@
+import { configureAnalyticsSnippet, installAnalyticsSnippet } from './snippet'
+
+const ANALYTICS_URL = 'https://analytics.example.com/aPath/aBundle.min.js'
+const WRITE_KEY = 'aWriteKey'
+
+const anyWindow = window as unknown as { analytics: any }
+
+function getInjectedScript() {
+  return document.querySelector('script[data-global-segment-analytics-key]')
+}
+
+describe('Analytics Snippet', () => {
+  beforeEach(() => {
+    delete (window as any).analytics
+    document.head.innerHTML = ''
+    document.body.innerHTML = ''
+    configureAnalyticsSnippet()
+    installAnalyticsSnippet()
+  })
+
+  describe('when a call is made before analytics.js is loaded', () => {
+    it('should queue it along the page context it was made in', () => {
+      anyWindow.analytics.track('Some Event', { aProperty: 'aValue' })
+
+      expect(anyWindow.analytics[0]).toEqual([
+        'track',
+        'Some Event',
+        { aProperty: 'aValue' },
+        expect.objectContaining({
+          __t: 'bpc',
+          p: window.location.pathname,
+          u: window.location.href
+        })
+      ])
+    })
+  })
+
+  describe('when a call is made after analytics.js is loaded', () => {
+    it('should forward it to the loaded analytics', () => {
+      const snippet = anyWindow.analytics
+      const track = jest.fn()
+      anyWindow.analytics = { initialized: true, track }
+
+      snippet.track('Some Event')
+
+      expect(track).toHaveBeenCalledWith('Some Event')
+    })
+  })
+
+  describe('when the snippet is not configured with an analytics url', () => {
+    it('should load the bundle from segment cdn', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(getInjectedScript()).toHaveProperty('src', `https://cdn.segment.com/analytics.js/v1/${WRITE_KEY}/analytics.min.js`)
+    })
+
+    it('should not set the cdn analytics.js resolves its settings from', () => {
+      expect(anyWindow.analytics._cdn).toBeUndefined()
+    })
+  })
+
+  describe('when the snippet is configured with an analytics url', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ analyticsUrl: ANALYTICS_URL })
+    })
+
+    it('should load the bundle from it', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(getInjectedScript()).toHaveProperty('src', ANALYTICS_URL)
+    })
+
+    it('should store the write key it was loaded with', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(anyWindow.analytics._writeKey).toBe(WRITE_KEY)
+    })
+
+    it('should resolve the settings from its origin', () => {
+      expect(anyWindow.analytics._cdn).toBe('https://analytics.example.com')
+    })
+  })
+
+  describe('when the snippet is configured with an analytics url and a cdn url', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({
+        analyticsUrl: ANALYTICS_URL,
+        cdnUrl: 'https://cdn.example.com'
+      })
+    })
+
+    it('should resolve the settings from the cdn url', () => {
+      expect(anyWindow.analytics._cdn).toBe('https://cdn.example.com')
+    })
+  })
+
+  describe('when the snippet is installed twice', () => {
+    let consoleError: jest.SpyInstance
+
+    beforeEach(() => {
+      consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+      installAnalyticsSnippet()
+    })
+
+    afterEach(() => {
+      consoleError.mockRestore()
+    })
+
+    it('should keep the snippet that was already installed and warn about it', () => {
+      expect(consoleError).toHaveBeenCalledWith('Segment snippet included twice.')
+    })
+  })
+})

--- a/src/modules/analytics/snippet.spec.ts
+++ b/src/modules/analytics/snippet.spec.ts
@@ -35,6 +35,12 @@ describe('Analytics Snippet', () => {
     })
   })
 
+  describe('when the methods this package calls are stubbed', () => {
+    it('should stub user, which getAnonymousId relies on', () => {
+      expect(typeof anyWindow.analytics.user).toBe('function')
+    })
+  })
+
   describe('when a call is made after analytics.js is loaded', () => {
     it('should forward it to the loaded analytics', () => {
       const snippet = anyWindow.analytics
@@ -78,6 +84,24 @@ describe('Analytics Snippet', () => {
 
     it('should resolve the settings from its origin', () => {
       expect(anyWindow.analytics._cdn).toBe('https://analytics.example.com')
+    })
+  })
+
+  describe('when the snippet is configured with a malformed analytics url', () => {
+    let consoleWarn: jest.SpyInstance
+
+    beforeEach(() => {
+      consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      configureAnalyticsSnippet({ analyticsUrl: 'http://[' })
+    })
+
+    afterEach(() => {
+      consoleWarn.mockRestore()
+    })
+
+    it('should warn about it and leave analytics.js resolving the settings on its own', () => {
+      expect(consoleWarn).toHaveBeenCalled()
+      expect(anyWindow.analytics._cdn).toBeUndefined()
     })
   })
 

--- a/src/modules/analytics/snippet.spec.ts
+++ b/src/modules/analytics/snippet.spec.ts
@@ -42,14 +42,27 @@ describe('Analytics Snippet', () => {
   })
 
   describe('when a call is made after analytics.js is loaded', () => {
-    it('should forward it to the loaded analytics', () => {
-      const snippet = anyWindow.analytics
-      const track = jest.fn()
-      anyWindow.analytics = { initialized: true, track }
+    let snippet: any
+    let loadedAnalytics: any
+    let track: jest.Mock
 
+    beforeEach(() => {
+      snippet = anyWindow.analytics
+      track = jest.fn(function (this: unknown) {
+        return this
+      })
+      loadedAnalytics = { initialized: true, track }
+      anyWindow.analytics = loadedAnalytics
+    })
+
+    it('should forward it to the loaded analytics', () => {
       snippet.track('Some Event')
 
       expect(track).toHaveBeenCalledWith('Some Event')
+    })
+
+    it('should forward it keeping the loaded analytics as the receiver', () => {
+      expect(snippet.track('Some Event')).toBe(loadedAnalytics)
     })
   })
 
@@ -84,6 +97,23 @@ describe('Analytics Snippet', () => {
 
     it('should resolve the settings from its origin', () => {
       expect(anyWindow.analytics._cdn).toBe('https://analytics.example.com')
+    })
+  })
+
+  describe('when the snippet is reconfigured without an analytics url', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ analyticsUrl: ANALYTICS_URL })
+      configureAnalyticsSnippet()
+    })
+
+    it('should stop resolving the settings from the previous cdn', () => {
+      expect(anyWindow.analytics._cdn).toBeUndefined()
+    })
+
+    it('should load the bundle from segment cdn', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(getInjectedScript()).toHaveProperty('src', `https://cdn.segment.com/analytics.js/v1/${WRITE_KEY}/analytics.min.js`)
     })
   })
 

--- a/src/modules/analytics/snippet.ts
+++ b/src/modules/analytics/snippet.ts
@@ -30,6 +30,8 @@ const METHODS = [
   'ready',
   'alias',
   'debug',
+  // Dropped by Segment in 5.2.0, kept because `getAnonymousId` calls it
+  'user',
   'page',
   'screen',
   'once',
@@ -52,7 +54,12 @@ function getAnalyticsUrl(writeKey: string) {
 }
 
 function getOrigin(url: string) {
-  return new URL(url, window.location.href).origin
+  try {
+    return new URL(url, window.location.href).origin
+  } catch (_error) {
+    console.warn(`Analytics: could not resolve the origin of the analytics url "${url}"`)
+    return undefined
+  }
 }
 
 /**

--- a/src/modules/analytics/snippet.ts
+++ b/src/modules/analytics/snippet.ts
@@ -75,8 +75,13 @@ export function configureAnalyticsSnippet(newOptions: AnalyticsSnippetOptions = 
   const analytics = (window as unknown as { analytics?: SegmentSnippet }).analytics
 
   // analytics.js resolves the settings endpoint from here, it can't infer it from a proxied bundle path
-  if (analytics && options.cdnUrl) {
-    analytics._cdn = options.cdnUrl
+  if (analytics) {
+    if (options.cdnUrl) {
+      analytics._cdn = options.cdnUrl
+    } else {
+      // Reconfiguring back to Segment's CDN, leaving the previous one would resolve the settings from a stale origin
+      delete analytics._cdn
+    }
   }
 }
 
@@ -105,10 +110,12 @@ export function installAnalyticsSnippet() {
   analytics.methods = METHODS
   analytics.factory = (method: string) => {
     return (...args: unknown[]): unknown => {
-      // Once analytics.js is loaded the global is the real one, so calls kept from the snippet are forwarded to it
-      if (anyWindow.analytics?.initialized) {
-        const initializedMethod = anyWindow.analytics[method] as (...args: unknown[]) => unknown
-        return initializedMethod(...args)
+      // Once analytics.js is loaded the global is the real one, so calls kept from the snippet are forwarded to it,
+      // keeping it as the receiver because its methods rely on the analytics instance as `this`
+      const loadedAnalytics = anyWindow.analytics
+      if (loadedAnalytics?.initialized) {
+        const initializedMethod = loadedAnalytics[method] as (...args: unknown[]) => unknown
+        return initializedMethod.apply(loadedAnalytics, args)
       }
 
       if (METHODS_WITH_PAGE_CONTEXT.includes(method)) {

--- a/src/modules/analytics/snippet.ts
+++ b/src/modules/analytics/snippet.ts
@@ -1,73 +1,155 @@
-// @ts-nocheck
-;(function () {
-  // Create a queue, but don't obliterate an existing one!
-  const analytics = (window.analytics = window.analytics || [])
+export type AnalyticsSnippetOptions = {
+  /**
+   * URL of the analytics.js bundle. Defaults to Segment's CDN, which ad blockers drop, so dapps can point it at a
+   * first party proxy instead.
+   */
+  analyticsUrl?: string
+  /**
+   * Origin analytics.js fetches its settings from. Defaults to the origin of `analyticsUrl`, which is what a proxy
+   * serving both the bundle and the settings needs.
+   */
+  cdnUrl?: string
+}
+
+type SegmentSnippet = any[] & Record<string, any>
+
+const GLOBAL_ANALYTICS_KEY = 'analytics'
+const SNIPPET_VERSION = '5.2.0'
+
+// Methods stubbed by the snippet, so calls made before analytics.js loads are queued and replayed afterwards
+const METHODS = [
+  'trackSubmit',
+  'trackClick',
+  'trackLink',
+  'trackForm',
+  'pageview',
+  'identify',
+  'reset',
+  'group',
+  'track',
+  'ready',
+  'alias',
+  'debug',
+  'page',
+  'screen',
+  'once',
+  'off',
+  'on',
+  'addSourceMiddleware',
+  'addIntegrationMiddleware',
+  'setAnonymousId',
+  'addDestinationMiddleware',
+  'register'
+]
+
+// Queued calls of these methods carry the page context of the moment they were made, not the one of the replay
+const METHODS_WITH_PAGE_CONTEXT = ['track', 'screen', 'alias', 'group', 'page', 'identify']
+
+const options: AnalyticsSnippetOptions = {}
+
+function getAnalyticsUrl(writeKey: string) {
+  return options.analyticsUrl || `https://cdn.segment.com/analytics.js/v1/${writeKey}/analytics.min.js`
+}
+
+function getOrigin(url: string) {
+  return new URL(url, window.location.href).origin
+}
+
+/**
+ * Points the snippet at a different analytics.js bundle. Takes effect on the next `analytics.load` call, so it must
+ * run before the analytics middleware is created.
+ */
+export function configureAnalyticsSnippet(newOptions: AnalyticsSnippetOptions = {}) {
+  if (typeof window === 'undefined') return
+
+  options.analyticsUrl = newOptions.analyticsUrl
+  options.cdnUrl = newOptions.cdnUrl || (newOptions.analyticsUrl ? getOrigin(newOptions.analyticsUrl) : undefined)
+
+  const analytics = (window as unknown as { analytics?: SegmentSnippet }).analytics
+
+  // analytics.js resolves the settings endpoint from here, it can't infer it from a proxied bundle path
+  if (analytics && options.cdnUrl) {
+    analytics._cdn = options.cdnUrl
+  }
+}
+
+/**
+ * Installs Segment's snippet, which queues every call made before analytics.js is loaded and replays them once it is.
+ */
+export function installAnalyticsSnippet() {
+  if (typeof window === 'undefined') return
+
+  const anyWindow = window as unknown as { analytics?: SegmentSnippet }
+
   // If the real analytics.js is already on the page return.
-  if (analytics.initialize) return
+  if (anyWindow.analytics?.initialize) return
+
   // If the snippet was invoked already show an error.
-  if (analytics.invoked) {
+  if (anyWindow.analytics?.invoked) {
     if (window.console && console.error) {
       console.error('Segment snippet included twice.')
     }
     return
   }
-  // Invoked flag, to make sure the snippet
-  // is never invoked twice.
+
+  const analytics = (anyWindow.analytics || []) as SegmentSnippet
+
   analytics.invoked = true
-  // A list of the methods in Analytics.js to stub.
-  analytics.methods = [
-    'trackSubmit',
-    'trackClick',
-    'trackLink',
-    'trackForm',
-    'pageview',
-    'identify',
-    'reset',
-    'group',
-    'track',
-    'ready',
-    'alias',
-    'debug',
-    'user',
-    'page',
-    'once',
-    'off',
-    'on',
-    'addSourceMiddleware',
-    'addIntegrationMiddleware',
-    'setAnonymousId',
-    'addDestinationMiddleware'
-  ]
-  // Define a factory to create stubs. These are placeholders
-  // for methods in Analytics.js so that you never have to wait
-  // for it to load to actually record data. The `method` is
-  // stored as the first argument, so we can replay the data.
-  analytics.factory = function (method) {
-    return function () {
-      const args = Array.prototype.slice.call(arguments)
-      args.unshift(method)
-      analytics.push(args)
+  analytics.methods = METHODS
+  analytics.factory = (method: string) => {
+    return (...args: unknown[]): unknown => {
+      // Once analytics.js is loaded the global is the real one, so calls kept from the snippet are forwarded to it
+      if (anyWindow.analytics?.initialized) {
+        const initializedMethod = anyWindow.analytics[method] as (...args: unknown[]) => unknown
+        return initializedMethod(...args)
+      }
+
+      if (METHODS_WITH_PAGE_CONTEXT.includes(method)) {
+        const canonical = document.querySelector("link[rel='canonical']")
+        args.push({
+          __t: 'bpc',
+          c: canonical?.getAttribute('href') || undefined,
+          p: window.location.pathname,
+          u: window.location.href,
+          s: window.location.search,
+          t: document.title,
+          r: document.referrer
+        })
+      }
+
+      analytics.push([method, ...args])
       return analytics
     }
   }
-  // For each of our methods, generate a queueing stub.
-  for (let i = 0; i < analytics.methods.length; i++) {
-    const key = analytics.methods[i]
-    analytics[key] = analytics.factory(key)
+
+  for (const method of METHODS) {
+    analytics[method] = analytics.factory(method)
   }
-  // Define a method to load Analytics.js from our CDN,
-  // and that will be sure to only ever load it once.
-  analytics.load = function (key, options) {
-    // Create an async script element based on your key.
+
+  analytics.load = (writeKey: string, loadOptions?: unknown) => {
     const script = document.createElement('script')
     script.type = 'text/javascript'
     script.async = true
-    script.src = 'https://cdn.segment.com/analytics.js/v1/' + key + '/analytics.min.js'
-    // Insert our script next to the first script element.
-    const first = document.getElementsByTagName('script')[0]
-    first.parentNode.insertBefore(script, first)
-    analytics._loadOptions = options
+    script.setAttribute('data-global-segment-analytics-key', GLOBAL_ANALYTICS_KEY)
+    script.src = getAnalyticsUrl(writeKey)
+
+    const firstScript = document.getElementsByTagName('script')[0]
+    if (firstScript?.parentNode) {
+      firstScript.parentNode.insertBefore(script, firstScript)
+    } else {
+      document.head.appendChild(script)
+    }
+
+    analytics._writeKey = writeKey
+    analytics._loadOptions = loadOptions
   }
-  // Add a version to keep track of what's in the wild.
-  analytics.SNIPPET_VERSION = '4.15.2'
-})()
+
+  if (options.cdnUrl) {
+    analytics._cdn = options.cdnUrl
+  }
+  analytics.SNIPPET_VERSION = SNIPPET_VERSION
+
+  anyWindow.analytics = analytics
+}
+
+installAnalyticsSnippet()

--- a/src/modules/analytics/snippet.ts
+++ b/src/modules/analytics/snippet.ts
@@ -50,16 +50,29 @@ const METHODS_WITH_PAGE_CONTEXT = ['track', 'screen', 'alias', 'group', 'page', 
 const options: AnalyticsSnippetOptions = {}
 
 function getAnalyticsUrl(writeKey: string) {
-  return options.analyticsUrl || `https://cdn.segment.com/analytics.js/v1/${writeKey}/analytics.min.js`
+  return options.analyticsUrl || `https://cdn.segment.com/analytics.js/v1/${encodeURIComponent(writeKey)}/analytics.min.js`
 }
 
-function getOrigin(url: string) {
+/**
+ * These urls end up loading a script and fetching the settings that decide which integrations run, so a value that is
+ * not a valid https url, or one of the dapp's own, is dropped instead of trusted.
+ */
+function resolveUrl(name: string, url: string) {
+  let resolved: URL
+
   try {
-    return new URL(url, window.location.href).origin
+    resolved = new URL(url, window.location.href)
   } catch (_error) {
-    console.warn(`Analytics: could not resolve the origin of the analytics url "${url}"`)
+    console.warn(`Analytics: ignoring the ${name} "${url}", it is not a valid url`)
     return undefined
   }
+
+  if (resolved.protocol !== 'https:' && resolved.origin !== window.location.origin) {
+    console.warn(`Analytics: ignoring the ${name} "${url}", it is not served over https`)
+    return undefined
+  }
+
+  return resolved
 }
 
 /**
@@ -69,8 +82,11 @@ function getOrigin(url: string) {
 export function configureAnalyticsSnippet(newOptions: AnalyticsSnippetOptions = {}) {
   if (typeof window === 'undefined') return
 
-  options.analyticsUrl = newOptions.analyticsUrl
-  options.cdnUrl = newOptions.cdnUrl || (newOptions.analyticsUrl ? getOrigin(newOptions.analyticsUrl) : undefined)
+  const analyticsUrl = newOptions.analyticsUrl ? resolveUrl('analytics url', newOptions.analyticsUrl) : undefined
+  const cdnUrl = newOptions.cdnUrl ? resolveUrl('cdn url', newOptions.cdnUrl) : undefined
+
+  options.analyticsUrl = analyticsUrl?.href
+  options.cdnUrl = cdnUrl ? newOptions.cdnUrl : analyticsUrl?.origin
 
   const analytics = (window as unknown as { analytics?: SegmentSnippet }).analytics
 

--- a/src/modules/analytics/utils.spec.ts
+++ b/src/modules/analytics/utils.spec.ts
@@ -423,6 +423,19 @@ describe('Analytics Utils', () => {
         expect(result).toBeUndefined()
       })
     })
+
+    describe('when analytics.js has not been loaded yet', () => {
+      beforeEach(() => {
+        // The snippet stubs `user` with a factory that queues the call and returns the queue itself
+        mockAnalytics.user.mockReturnValue([])
+      })
+
+      it('should return undefined', () => {
+        const result = getAnonymousId()
+
+        expect(result).toBeUndefined()
+      })
+    })
   })
 
   describe('hasEvmWallet function', () => {

--- a/src/modules/analytics/utils.ts
+++ b/src/modules/analytics/utils.ts
@@ -98,11 +98,13 @@ export function trackConnectWallet(
 
 export function getAnonymousId() {
   const analytics = getAnalytics()
-  if (analytics) {
-    return analytics.user().anonymousId()
-  } else {
+  if (!analytics) {
     return undefined
   }
+
+  // Until analytics.js is loaded `user` is one of the snippet stubs, which has no anonymous id to return yet
+  const user = analytics.user()
+  return typeof user?.anonymousId === 'function' ? user.anonymousId() : undefined
 }
 
 export function hasEvmWallet() {


### PR DESCRIPTION
## What

Lets a dapp load `analytics.js` from its own URL instead of Segment's CDN:

```ts
const analyticsMiddleware = createAnalyticsMiddleware(SEGMENT_WRITE_KEY, {
  analyticsUrl: 'https://analytics.example.org/aPath/aBundle.min.js'
})
```

- `snippet.ts` is now Segment's snippet `5.2.0` (was `4.15.2`), written as `installAnalyticsSnippet`, still installed on import so nothing changes for the dapps that only import the middleware.
- `configureAnalyticsSnippet` sets the bundle URL and the `_cdn` `analytics.js` resolves its settings from, defaulting to the origin of the bundle URL. `createAnalyticsMiddleware` calls it with its new (optional) second argument before `load`.
- Both are exported from `modules/analytics`, and the middleware section of the README documents the option.

## Why

The snippet hardcoded `https://cdn.segment.com/analytics.js/v1/<write-key>/analytics.min.js` with no way to override it, and ad blockers drop that request, so those sessions send no events at all. Serving the same bundle from a first party proxy fixes it, but every dapp needs the URL to be configurable to do so.

Marketplace is the first consumer (its own workaround is https://github.com/decentraland/marketplace/pull/2679, which this replaces).

## Compatibility

- `createAnalyticsMiddleware(apiKey)` keeps working as is and keeps loading the bundle from Segment's CDN.
- The snippet upgrade brings the stubs of `screen` and `register`, the `data-global-segment-analytics-key` attribute, and the page context (`__t: 'bpc'`) that Segment attaches to the calls queued before the bundle loads, so they are attributed to the page they were made in.
- `installAnalyticsSnippet` and `configureAnalyticsSnippet` are no-ops when there is no `window`, the snippet used to throw on import outside the browser.

## Test

`src/modules/analytics/snippet.spec.ts` covers the queueing and the forwarding of calls once `analytics.js` is loaded, the default and the configured bundle URLs, the `_cdn` resolution, and the duplicated install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)