### PR TITLE
fix: point ContentfulClient to cms-api.decentraland.org

### DIFF
--- a/src/modules/campaign/ContentfulClient.spec.ts
+++ b/src/modules/campaign/ContentfulClient.spec.ts
@@ -4,7 +4,7 @@ import { mockAdminEntryEn, marketplaceHomepageBannerAssets, mockHomepageBannerEn
 import { ContentfulLocale, LocalizedField } from '@dcl/schemas'
 import { ContentfulEntryWithoutLocales } from './ContentfulClient.types'
 
-const CMS_URL = 'https://cms.decentraland.org'
+const CMS_URL = 'https://cms-api.decentraland.org'
 
 describe('ContentfulClient', () => {
   let client: ContentfulClient

--- a/src/modules/campaign/ContentfulClient.ts
+++ b/src/modules/campaign/ContentfulClient.ts
@@ -18,7 +18,7 @@ type ImageOptimized = ImageOptimizedFormats &
 
 export class ContentfulClient extends BaseClient {
   constructor() {
-    super('https://cms.decentraland.org')
+    super('https://cms-api.decentraland.org')
   }
 
   async fetchEntry<T extends Fields>(


### PR DESCRIPTION
`ContentfulClient` was pointing to `https://cms.decentraland.org`. The correct API host is `https://cms-api.decentraland.org`.

Updates the client base URL and the `CMS_URL` constant used by the nock mocks in the tests.

`cms-images.decentraland.org` (used in `optimize()` for optimized assets) is a different host and stays unchanged.

Verification: `npm run build` and `jest src/modules/campaign/ContentfulClient.spec.ts` (10/10) pass.
