### PR TITLE
chore: bump decentraland-ui2 to ^3.19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "@typescript-eslint/parser": "8.52.0",
         "decentraland-connect": "^12.0.0",
         "decentraland-ui": "^7.1.0",
-        "decentraland-ui2": "^3.15.0",
+        "decentraland-ui2": "^3.19.2",
         "eslint": "9.39.2",
         "eslint-config-prettier": "10.1.8",
         "eslint-import-resolver-typescript": "4.4.4",
@@ -15188,9 +15188,9 @@
       "license": "ISC"
     },
     "node_modules/decentraland-ui2": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.15.0.tgz",
-      "integrity": "sha512-FrgTwh5XURVateMHR8GBWrjS3WtEl1F5I+GjUl1+hJt7MPI4Lb6ZeHfGde3MezJxIV2BjdGuyR4TdJ1CwZMaDQ==",
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.19.2.tgz",
+      "integrity": "sha512-3Xf5Gkqvq7nBeaTyG+YdzM7iEo8p0JjL6wDoCD1ogiu/GWRYWLwcNTb7qm19lp+HLY19FTB46IH1j0Tgxl9r0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@typescript-eslint/parser": "8.52.0",
     "decentraland-connect": "^12.0.0",
     "decentraland-ui": "^7.1.0",
-    "decentraland-ui2": "^3.15.0",
+    "decentraland-ui2": "^3.19.2",
     "eslint": "9.39.2",
     "eslint-config-prettier": "10.1.8",
     "eslint-import-resolver-typescript": "4.4.4",


### PR DESCRIPTION
Moves the `decentraland-ui2` dev dependency from `^3.15.0` to `^3.19.2` so the version this library builds and tests against carries the `Banner` artwork fix released in ui2 3.19.2 (decentraland/ui2#468).

Before that fix, the `Banner` this library wraps in `src/containers/Banner` sized itself only after its copy. A campaign banner whose artwork is a 1920x300 hero rendered in a 117px tall box, so `background-size: cover` cropped 48% of the image and the copy ran across the subject of the art.

The `peerDependencies` range stays at `^3.0.0`: consumers already resolve 3.19.2 through it, and narrowing it would force a bump on every dapp for no reason.

### Verification

- `npm run lint` (0 errors, the 236 warnings are pre-existing), `npm run lint:pkg` and `npm run build` pass.
- `npm test`: 51 suites, 701 passed, 1 skipped.
- The rendered result was checked end to end before opening this: with ui2 3.19.2 linked into a local marketplace, the homepage campaign banner goes from 1449x117 with the art cropped in half to 1352x211, matching the artwork's 6.4 ratio, and it grows instead of clipping when the copy needs more room.
