### PR TITLE
chore: require decentraland-ui2 ^3.19.2 as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "@dcl/ui-env": "^2.0.0",
         "decentraland-connect": "^12.0.0",
         "decentraland-ui": "^7.1.0",
-        "decentraland-ui2": "^3.0.0",
+        "decentraland-ui2": "^3.19.2",
         "ethers": "^5.7.2",
         "history": "^4.10.1",
         "react": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@dcl/ui-env": "^2.0.0",
     "decentraland-connect": "^12.0.0",
     "decentraland-ui": "^7.1.0",
-    "decentraland-ui2": "^3.0.0",
+    "decentraland-ui2": "^3.19.2",
     "ethers": "^5.7.2",
     "history": "^4.10.1",
     "react": "^18.0.0",


### PR DESCRIPTION
Follow up to #816, which bumped the dev dependency only. The peer range stayed at `^3.0.0`, so nothing stopped a consumer from resolving an older ui2 while this library kept wrapping a `Banner` that needs the artwork sizing fix released in 3.19.2 (decentraland/ui2#468). On ui2 3.8.0 the campaign banner this library exposes through `src/containers/Banner` still crops roughly half of a 1920x300 hero.

Raising the floor to `^3.19.2` makes the requirement explicit: npm now warns a consumer whose lockfile is behind, instead of the mismatch showing up as a visually broken banner.

Still inside major 3, so consumers already on `^3.x` only need to refresh their lockfile. `marketplace` is doing exactly that in decentraland/marketplace#2685.

### Verification

- `npm run lint` (0 errors, 236 pre-existing warnings), `npm run lint:pkg` and `npm run build` pass.
- `npm test`: 51 suites, 701 passed, 1 skipped.
