### PR TITLE
fix(auth): upgrade decentraland-crypto-fetch to 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@wert-io/widget-initializer": "6.8.0",
         "date-fns": "1.30.1",
         "dcl-catalyst-client": "^22.0.0",
-        "decentraland-crypto-fetch": "^2.0.1",
+        "decentraland-crypto-fetch": "^3.0.0",
         "decentraland-transactions": "^3.0.2",
         "events": "3.3.0",
         "eventsource": "3.0.7",
@@ -13470,16 +13470,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/core-js-pure": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.0.tgz",
-      "integrity": "sha512-+2KbMFGeBU0ln/csoPqTe0i/yfHbrd2EUhNMObsGtXMKS/RTtlkYyi+/3twLcevbgNR0yM/r0Psa3TEoQRpFMQ==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -15087,16 +15077,15 @@
       }
     },
     "node_modules/decentraland-crypto-fetch": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/decentraland-crypto-fetch/-/decentraland-crypto-fetch-2.0.1.tgz",
-      "integrity": "sha512-2IKu6Y4k/fle8bmU0b4zy7V1i1R0oCXtqlJumBXc4jwHUHKAcHDLD2YtgJFdd7JjsWQwf+t0DsKpzBCjQDKANg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/decentraland-crypto-fetch/-/decentraland-crypto-fetch-3.0.0.tgz",
+      "integrity": "sha512-kp4DFAz4cv9y89qiXpIGtDm5DtNMk6t8k5zboC0Pvde/+2/ftrEhBQBibFU1ZV/xP2Pwfn+ZBr7ZYqNoV5DBSQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@dcl/crypto": "^3.3.1",
-        "core-js-pure": "^3.19.1"
+        "@dcl/crypto": "3.7.0"
       },
       "engines": {
-        "node": ">=12",
-        "npm": ">=6"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/decentraland-transactions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "validate-commit-message": "3.2.0"
       },
       "engines": {
-        "node": ">=20.0.0",
+        "node": ">=22.0.0",
         "npm": ">=10.0.0"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "url": "git+https://github.com/decentraland/decentraland-dapps.git"
   },
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "npm": ">=10.0.0"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@wert-io/widget-initializer": "6.8.0",
     "date-fns": "1.30.1",
     "dcl-catalyst-client": "^22.0.0",
-    "decentraland-crypto-fetch": "^2.0.1",
+    "decentraland-crypto-fetch": "^3.0.0",
     "decentraland-transactions": "^3.0.2",
     "events": "3.3.0",
     "eventsource": "3.0.7",
@@ -126,6 +126,11 @@
   "engines": {
     "node": ">=20.0.0",
     "npm": ">=10.0.0"
+  },
+  "overrides": {
+    "@dcl/hooks": {
+      "decentraland-crypto-fetch": "$decentraland-crypto-fetch"
+    }
   },
   "publishConfig": {
     "provenance": true


### PR DESCRIPTION
Upgrades `decentraland-crypto-fetch` from `^2.0.1` to `^3.0.0`.

## What changed

`decentraland-crypto-fetch` 3.0.0 changes the signed-fetch payload format to match `@dcl/crypto-middleware` 6.x:

- **Old:** `[method, path, timestamp, metadata].join(':').toLowerCase()` — the whole payload lowercased, metadata included.
- **New:** `[method.toLowerCase(), path.toLowerCase(), timestamp, metadata].join(':')` — only method and path are lowercased; the metadata is joined verbatim, so its casing is covered by the signature.

The format lives entirely inside the package, so the dependency bump is the whole change. This repo is a signer only — it does not verify anything — and it does not hand-roll a signed-fetch payload anywhere, so no source changes were needed.

## Deploy ordering — this one is ordering-sensitive

This library now signs the new format, so a signed request only verifies against a service already running `@dcl/crypto-middleware` 6.x. Services are being upgraded in parallel.

Where every piece of signed metadata is already all-lowercase, both formats produce identical bytes and the change is inert. **That is not the case here.**

`markNotificationsAsRead` (`PUT /notifications/read`, notifications service) signs this metadata:

```ts
metadata: {
  notificationIds: ids,
  signer: 'dcl:navbar',
  intent: 'dcl:navbar:read-notifications'
}
```

The `notificationIds` **key** contains an uppercase `I`. Under the old format the whole payload was lowercased, so the server saw `notificationids`; under the new format it is signed verbatim as `notificationIds`. The bytes differ, so the signature differs.

**Consequence:** if this ships to a consumer before the notifications service is on `@dcl/crypto-middleware` 6.x, `markNotificationsAsRead` gets a `401`. That call should be verified against an upgraded notifications service before release.

Every other signed call site sends all-lowercase metadata and is inert either way:

| Call site | Metadata | Status |
| --- | --- | --- |
| `AuthClient.createIdentityId` | `signer: 'dcl:auth'`, `intent: 'dcl:auth:create-identity'` | inert |
| `getNotifications` | `signer: 'dcl:navbar'`, `intent: 'dcl:navbar:see-notifications'` | inert |
| `markNotificationsAsRead` | `notificationIds`, `signer`, `intent` | **ordering-sensitive** |
| subscription / email calls | `signer: 'dcl:account'`, `intent: 'dcl:account:manage-subscription'` | inert |
| `TradesAPI.addTrade` | `signer: this.signer`, `intent: 'dcl:create-trade'` | depends on consumer |
| `credits.useShopCreditsCollectionManager` | no metadata | inert |

One caveat on `TradesAPI.addTrade`: its `signer` is the `dappSigner` string passed in by the consuming dapp, so this repo cannot guarantee its casing. If a consumer passes a signer containing uppercase characters, that call becomes ordering-sensitive too.

## Install resolution — why there is an `overrides` entry

`@dcl/hooks` declares `decentraland-crypto-fetch@^2.0.1` as a peer dependency, and it reaches this
repo transitively, as a peer of the `decentraland-ui2` devDependency:

```
root (dev) -> decentraland-ui2@3.19.2
                -> peer @dcl/hooks@^1.2.1  (resolves 1.3.0)
                     -> peer decentraland-crypto-fetch@^2.0.1
```

With the root on `^3.0.0` npm cannot satisfy both, so `npm install` fails with `ERESOLVE` and every
workflow (`audit`, `lint-package-json`, `Build and Test`) dies before running anything.

No published `@dcl/hooks` accepts 3.x — all 50 versions from `1.1.1` onward pin `^2.0.1` — so bumping
it is not an option.

That pin is over-restrictive rather than meaningful:

- hooks' only use of the package is `signedFetchFactory()` in
  `esm/clients/notifications/createNotificationsClient.js`, and that function's signature is unchanged
  between 2.0.1 and 3.0.0.
- neither of its two signed calls passes any metadata. `notificationIds` travels in the request
  **body**, not in signed metadata, so hooks produces byte-identical payloads under both formats and is
  unaffected by the 3.0.0 format change.

So this declares that, and nothing more:

```json
"overrides": {
  "@dcl/hooks": {
    "decentraland-crypto-fetch": "$decentraland-crypto-fetch"
  }
}
```

It changes no resolution: `package-lock.json` is **byte-identical** after the change, with no package
added, removed or re-versioned. `npm install`, `npm ci` and `npm audit signatures` all succeed.

**This unblocks this repo only.** npm honours `overrides` in the root project, so the field is inert
for consumers of the published package — the durable fix is to widen the peer range in `@dcl/hooks`
to `^2.0.1 || ^3.0.0`. Until that ships, a consumer taking this release alongside `decentraland-ui2`
needs the same override at its own root (this is what [builder#3469](https://github.com/decentraland/builder/pull/3469) is hitting).

## Testing

- `npm install` resolves, `npm ci` resolves, `npm audit signatures` verifies 1963 packages.
- `npm run build` (tsc) passes.
- `npmPkgJsonLint .` passes — `overrides` is placed between `engines` and `publishConfig`, which the
  shared `prefer-absolute-version` / `prefer-property-order` config requires as an error-level rule.
- `npm test`: **51 suites, 701 passed, 1 skipped**, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

