### PR TITLE
feat: sign trades against the newest off-chain marketplace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "date-fns": "1.30.1",
         "dcl-catalyst-client": "^22.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-transactions": "^3.1.0",
+        "decentraland-transactions": "^3.1.1",
         "events": "3.3.0",
         "eventsource": "3.0.7",
         "flat": "5.0.2",
@@ -15100,9 +15100,9 @@
       }
     },
     "node_modules/decentraland-transactions": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-3.1.0.tgz",
-      "integrity": "sha512-0FkDVXZJIWkSjAFaZnNWFKHrBGAZ5k0pAQdusEmkncWGqVsN39yLfmLOFkloODkO8sRAmTOTdr41GqsNbE8PlQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-3.1.1.tgz",
+      "integrity": "sha512-DCGKX9hc4vknDm9FXY1w/nGGNEFzjpvSwwl1zetmpLJQh1PHNJB91xV6nZRS6UbOuE51v2juZZOA/yI1oaGfAg==",
       "dependencies": {
         "tslib": "^2.6.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "date-fns": "1.30.1",
         "dcl-catalyst-client": "^22.0.0",
         "decentraland-crypto-fetch": "^2.0.1",
-        "decentraland-transactions": "^3.0.2",
+        "decentraland-transactions": "^3.1.0",
         "events": "3.3.0",
         "eventsource": "3.0.7",
         "flat": "5.0.2",
@@ -15100,9 +15100,9 @@
       }
     },
     "node_modules/decentraland-transactions": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-3.0.2.tgz",
-      "integrity": "sha512-M8m1Uy8WrZ+GxZ/IH1PTA5B3WIYvJAcrtcDZMpdkaK9y/KUi0Vmlk3Qp07FPCLsUyZiFR/wh8HToSq0N0warrA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-3.1.0.tgz",
+      "integrity": "sha512-0FkDVXZJIWkSjAFaZnNWFKHrBGAZ5k0pAQdusEmkncWGqVsN39yLfmLOFkloODkO8sRAmTOTdr41GqsNbE8PlQ==",
       "dependencies": {
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "date-fns": "1.30.1",
     "dcl-catalyst-client": "^22.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-transactions": "^3.0.2",
+    "decentraland-transactions": "^3.1.0",
     "events": "3.3.0",
     "eventsource": "3.0.7",
     "flat": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "date-fns": "1.30.1",
     "dcl-catalyst-client": "^22.0.0",
     "decentraland-crypto-fetch": "^2.0.1",
-    "decentraland-transactions": "^3.1.0",
+    "decentraland-transactions": "^3.1.1",
     "events": "3.3.0",
     "eventsource": "3.0.7",
     "flat": "5.0.2",

--- a/src/lib/trades.spec.ts
+++ b/src/lib/trades.spec.ts
@@ -13,7 +13,13 @@ import {
 import * as ethUtils from './eth'
 import { ContractData, ContractName, getContract } from 'decentraland-transactions'
 import { fromMillisecondsToSeconds } from '../lib/time'
-import { OFFCHAIN_MARKETPLACE_TYPES, getTradeSignature, getOnChainTrade, getValueForTradeAsset } from './trades'
+import {
+  OFFCHAIN_MARKETPLACE_TYPES,
+  getLatestOffChainMarketplaceContract,
+  getTradeSignature,
+  getOnChainTrade,
+  getValueForTradeAsset
+} from './trades'
 
 jest.mock('./eth', () => {
   const module = jest.requireActual('./eth')
@@ -165,7 +171,7 @@ describe('when getting the trade signature', () => {
       signer = ethers.Wallet.createRandom().connect(ethers.providers.getDefaultProvider())
       jest.spyOn(ethUtils, 'getSigner').mockImplementation(() => Promise.resolve(signer))
       signerAddress = (await signer.getAddress()).toLowerCase()
-      offchainMarketplaceContract = getContract(ContractName.OffChainMarketplaceV2, ChainId.ETHEREUM_SEPOLIA)
+      offchainMarketplaceContract = getLatestOffChainMarketplaceContract(ChainId.ETHEREUM_SEPOLIA)
 
       trade = {
         signer: signerAddress,
@@ -202,7 +208,7 @@ describe('when getting the trade signature', () => {
       }
 
       const SALT = ethers.utils.hexZeroPad(ethers.utils.hexlify(trade.chainId), 32)
-      offchainMarketplaceContract = getContract(ContractName.OffChainMarketplaceV2, trade.chainId)
+      offchainMarketplaceContract = getLatestOffChainMarketplaceContract(trade.chainId)
       domain = {
         name: offchainMarketplaceContract.name,
         version: offchainMarketplaceContract.version,
@@ -322,6 +328,51 @@ describe('when getting the trade to accept', () => {
         extra: '0x',
         beneficiary: asset.beneficiary
       }))
+    })
+  })
+})
+
+describe('when getting the latest off-chain marketplace contract', () => {
+  describe('and the chain has a V3 deployment', () => {
+    let chainId: ChainId
+
+    beforeEach(() => {
+      chainId = ChainId.MATIC_AMOY
+    })
+
+    it('should return V3, so new trades settle on the newest deployment', () => {
+      expect(getLatestOffChainMarketplaceContract(chainId).address).toBe(
+        getContract(ContractName.OffChainMarketplaceV3, chainId).address
+      )
+    })
+  })
+
+  describe('and the chain has no V3 deployment', () => {
+    let chainId: ChainId
+
+    beforeEach(() => {
+      chainId = ChainId.MATIC_MAINNET
+    })
+
+    // V3 is testnet-only for now. Falling back rather than throwing is what keeps mainnet listings working.
+    it('should fall back to V2', () => {
+      expect(getLatestOffChainMarketplaceContract(chainId).address).toBe(
+        getContract(ContractName.OffChainMarketplaceV2, chainId).address
+      )
+    })
+  })
+
+  describe('and the chain has no off-chain marketplace at all', () => {
+    let chainId: ChainId
+
+    beforeEach(() => {
+      chainId = ChainId.ARBITRUM_MAINNET
+    })
+
+    it('should throw naming the chain', () => {
+      expect(() => getLatestOffChainMarketplaceContract(chainId)).toThrowError(
+        `No off-chain marketplace contract exists on chain ${chainId}`
+      )
     })
   })
 })

--- a/src/lib/trades.ts
+++ b/src/lib/trades.ts
@@ -45,12 +45,38 @@ export const OFFCHAIN_MARKETPLACE_TYPES: Record<string, TypedDataField[]> = {
   ]
 }
 
+/**
+ * Off-chain marketplace versions, newest first.
+ *
+ * The EIP-712 domain names its verifying contract, so the version a trade is signed against is part of
+ * what the signer signed. Trades should settle on the newest deployment, but V3 is testnet-only for now,
+ * so mainnet has to keep using V2 rather than fail.
+ */
+const OFF_CHAIN_MARKETPLACE_CONTRACT_NAMES = [ContractName.OffChainMarketplaceV3, ContractName.OffChainMarketplaceV2]
+
+/**
+ * The newest off-chain marketplace deployed on a chain.
+ *
+ * `getContract` THROWS for a version that is not deployed on the given chain rather than returning a
+ * falsy value, which is why each candidate is tried in turn.
+ */
+export function getLatestOffChainMarketplaceContract(chainId: ChainId): ContractData {
+  for (const contractName of OFF_CHAIN_MARKETPLACE_CONTRACT_NAMES) {
+    try {
+      return getContract(contractName, chainId)
+    } catch (_error) {
+      continue
+    }
+  }
+  throw new Error(`No off-chain marketplace contract exists on chain ${chainId}`)
+}
+
 export async function getOffChainMarketplaceContract(chainId: ChainId) {
   const provider = await getNetworkProvider(chainId)
   if (!provider) {
     throw new Error('Could not get connected provider')
   }
-  const { address, abi } = getContract(ContractName.OffChainMarketplaceV2, chainId)
+  const { address, abi } = getLatestOffChainMarketplaceContract(chainId)
   const instance = new Contract(address, abi, new Web3Provider(provider))
   return instance
 }
@@ -144,11 +170,7 @@ export function getOnChainTrade(trade: Trade, sentBeneficiaryAddress: string): O
 }
 
 export async function getTradeSignature(trade: Omit<TradeCreation, 'signature'>) {
-  const marketplaceContract: ContractData = getContract(ContractName.OffChainMarketplaceV2, trade.chainId)
-
-  if (!marketplaceContract) {
-    throw new Error(`The ${ContractName.OffChainMarketplace} contract doesn't exist on chain ${trade.chainId}`)
-  }
+  const marketplaceContract: ContractData = getLatestOffChainMarketplaceContract(trade.chainId)
 
   const signer = (await getSigner()) as JsonRpcSigner
   const SALT = hexZeroPad(hexlify(trade.chainId), 32)


### PR DESCRIPTION

## What

`getOffChainMarketplaceContract` and `getTradeSignature` were both pinned to `ContractName.OffChainMarketplaceV2`. They now resolve the newest off-chain marketplace deployed on the trade's chain, so testnets move to V3 while mainnet keeps using V2 until V3 ships there.

## Why a fallback rather than a switch

The EIP-712 domain names its verifying contract, so the marketplace version is part of what the signer signed — `getTradeSignature` is what sets `verifyingContract`, and a trade signed against the wrong version is rejected on chain.

V3 is testnet-only for now, and `getContract` **throws** for a version that is not deployed on a chain rather than returning a falsy value. So an unconditional switch to V3 would throw on every mainnet listing. `getLatestOffChainMarketplaceContract` tries V3 then V2 and returns the first that exists.

Server side, `marketplace-server` accepts a trade signed against **either** version (decentraland/marketplace-server#395), so this needs no deploy-ordering with the backend in either direction.

## Also in here

Dropped the dead `if (!marketplaceContract)` branch in `getTradeSignature`. It could never run — `getContract` throws rather than returning falsy — and its error message named `OffChainMarketplace` while the lookup used `OffChainMarketplaceV2`. The new resolver throws a message that names the chain instead.

## Unaffected on purpose

- `TradeService.accept` / `.cancel` resolve their contract from `getContractName(trade.contract)`, which is address-driven, so they pick up V3 automatically once the registry knows its addresses — that is what 3.1.0 adds.
- `lib/credits.ts` likewise resolves via `getContractName(trade.contract)`, so a credits-funded purchase of a V3 trade already targets the right marketplace.

## Dependency note

This needed `decentraland-transactions` **3.1.1**, now released. 3.1.0's root entrypoint re-exported `./crossChain`, which imports `@0xsquid/sdk` — an optional peer — so `require('decentraland-transactions')` threw for anything that did not install it. decentraland/decentraland-transactions#134 removed that re-export. The lockfile pins 3.1.1, and I verified the root import resolves with `@0xsquid` **not** installed.

## Testing

`src/lib/trades.spec.ts` and `src/lib/credits.spec.ts` pass — 40 tests. New cases cover the resolver returning V3 on Amoy, falling back to V2 on Polygon mainnet, and throwing on a chain with no marketplace at all. The signing tests now build their expected domain from the resolver, so they verify the signature against whichever version the library actually picked.

Full suite: 701 passing, with one pre-existing unrelated failure (`src/modules/credits/reducer.spec.ts` imports `decentraland-dapps/dist/...`, which needs a built `dist`; it fails identically on `master`).
