### PR TITLE
fix: reserve the navbar height ui2 3.x actually uses

### DIFF
--- a/src/containers/Navbar/Navbar2.styled.ts
+++ b/src/containers/Navbar/Navbar2.styled.ts
@@ -1,7 +1,14 @@
 import { Box, styled } from 'decentraland-ui2'
 
+// The ui2 navbar is `position: fixed`, so this padding is the only thing keeping
+// the page out from under it, and it has to track the bar's own heights: 64px
+// below 992px and 92px above it. It read 66px, which was the height before ui2
+// 3.x and left 26px of every consumer's content sitting behind the bar.
 const NavbarContainer = styled(Box)({
-  paddingTop: '66px',
+  paddingTop: '64px',
+  '@media (min-width: 992px)': {
+    paddingTop: '92px'
+  },
   width: '100%'
 })
 


### PR DESCRIPTION
`Navbar2`'s container reserves `paddingTop: 66px`, but the ui2 navbar it renders is `position: fixed` and 64px tall below 992px, 92px above it. 66px was the height before ui2 3.x, so the container under-reserves by 26px on desktop.

The padding now tracks the bar's own two heights.

### Do not merge this on its own

Measured in production, every consumer already carries its own patch for this, with a different mechanism and a different number each time:

| App | ui2 navbar | Container reserves | Local compensation | Result today |
| --- | --- | --- | --- | --- |
| marketplace | 92px | 66px | `margin-bottom: 36px` on the navbar wrapper in `PageLayout.module.css`, zeroed by `.navbarWithAnnouncement` while the announcement bar shows | no overlap |
| builder | 92px | 66px | `margin-top: 26px` on the `<aside>` bar that follows the navbar | no overlap |
| dao-landing | 92px | 66px | none | hero sits 26px under the bar |

So nothing is visibly broken in production right now, and this fix alone would make two of them worse: with the container corrected to 92px, those compensations stack and marketplace and builder each gain 26px of dead space.

This needs to land with the consumers dropping their patches:

- **marketplace** — remove the `margin-bottom: 36px` rule and the `.navbarWithAnnouncement` exception that exists only to cancel it.
- **builder** — remove the `margin-top: 26px` on the bar.
- **dao-landing** — nothing to remove; it just stops overlapping. decentraland/dao-landing#645 is blocked on a release carrying this.

The reason to fix it here rather than add a fourth patch is exactly the table above: three apps, three different numbers, and a marketplace rule whose spacing depends on which banner happens to be visible.

### How to test

In any app that renders `Navbar2`, at a desktop width:

```js
const nav = document.querySelector('nav')
const spacer = nav.closest('div')
spacer.getBoundingClientRect().height // 66 before, 92 after
```

Then check the first element after the navbar wrapper starts at or below the bar's bottom edge, with no gap beyond what the design calls for. Worth a look below 992px too, where the reserved space goes from 66px to the bar's actual 64px.
