### PR TITLE
feat: sign trades against the newest off-chain marketplace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "date-fns": "1.30.1",
         "dcl-catalyst-client": "^22.0.0",
         "decentraland-crypto-fetch": "^3.0.0",
-        "decentraland-transactions": "^3.0.2",
+        "decentraland-transactions": "^3.1.1",
         "events": "3.3.0",
         "eventsource": "3.0.7",
         "flat": "5.0.2",
@@ -15089,9 +15089,9 @@
       }
     },
     "node_modules/decentraland-transactions": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-3.0.2.tgz",
-      "integrity": "sha512-M8m1Uy8WrZ+GxZ/IH1PTA5B3WIYvJAcrtcDZMpdkaK9y/KUi0Vmlk3Qp07FPCLsUyZiFR/wh8HToSq0N0warrA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/decentraland-transactions/-/decentraland-transactions-3.1.1.tgz",
+      "integrity": "sha512-DCGKX9hc4vknDm9FXY1w/nGGNEFzjpvSwwl1zetmpLJQh1PHNJB91xV6nZRS6UbOuE51v2juZZOA/yI1oaGfAg==",
       "dependencies": {
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "date-fns": "1.30.1",
     "dcl-catalyst-client": "^22.0.0",
     "decentraland-crypto-fetch": "^3.0.0",
-    "decentraland-transactions": "^3.0.2",
+    "decentraland-transactions": "^3.1.1",
     "events": "3.3.0",
     "eventsource": "3.0.7",
     "flat": "5.0.2",

--- a/src/lib/trades.spec.ts
+++ b/src/lib/trades.spec.ts
@@ -13,7 +13,13 @@ import {
 import * as ethUtils from './eth'
 import { ContractData, ContractName, getContract } from 'decentraland-transactions'
 import { fromMillisecondsToSeconds } from '../lib/time'
-import { OFFCHAIN_MARKETPLACE_TYPES, getTradeSignature, getOnChainTrade, getValueForTradeAsset } from './trades'
+import {
+  OFFCHAIN_MARKETPLACE_TYPES,
+  getLatestOffChainMarketplaceContract,
+  getTradeSignature,
+  getOnChainTrade,
+  getValueForTradeAsset
+} from './trades'
 
 jest.mock('./eth', () => {
   const module = jest.requireActual('./eth')
@@ -165,7 +171,7 @@ describe('when getting the trade signature', () => {
       signer = ethers.Wallet.createRandom().connect(ethers.providers.getDefaultProvider())
       jest.spyOn(ethUtils, 'getSigner').mockImplementation(() => Promise.resolve(signer))
       signerAddress = (await signer.getAddress()).toLowerCase()
-      offchainMarketplaceContract = getContract(ContractName.OffChainMarketplaceV2, ChainId.ETHEREUM_SEPOLIA)
+      offchainMarketplaceContract = getLatestOffChainMarketplaceContract(ChainId.ETHEREUM_SEPOLIA)
 
       trade = {
         signer: signerAddress,
@@ -202,7 +208,7 @@ describe('when getting the trade signature', () => {
       }
 
       const SALT = ethers.utils.hexZeroPad(ethers.utils.hexlify(trade.chainId), 32)
-      offchainMarketplaceContract = getContract(ContractName.OffChainMarketplaceV2, trade.chainId)
+      offchainMarketplaceContract = getLatestOffChainMarketplaceContract(trade.chainId)
       domain = {
         name: offchainMarketplaceContract.name,
         version: offchainMarketplaceContract.version,
@@ -322,6 +328,51 @@ describe('when getting the trade to accept', () => {
         extra: '0x',
         beneficiary: asset.beneficiary
       }))
+    })
+  })
+})
+
+describe('when getting the latest off-chain marketplace contract', () => {
+  describe('and the chain has a V3 deployment', () => {
+    let chainId: ChainId
+
+    beforeEach(() => {
+      chainId = ChainId.MATIC_AMOY
+    })
+
+    it('should return V3, so new trades settle on the newest deployment', () => {
+      expect(getLatestOffChainMarketplaceContract(chainId).address).toBe(
+        getContract(ContractName.OffChainMarketplaceV3, chainId).address
+      )
+    })
+  })
+
+  describe('and the chain has no V3 deployment', () => {
+    let chainId: ChainId
+
+    beforeEach(() => {
+      chainId = ChainId.MATIC_MAINNET
+    })
+
+    // V3 is testnet-only for now. Falling back rather than throwing is what keeps mainnet listings working.
+    it('should fall back to V2', () => {
+      expect(getLatestOffChainMarketplaceContract(chainId).address).toBe(
+        getContract(ContractName.OffChainMarketplaceV2, chainId).address
+      )
+    })
+  })
+
+  describe('and the chain has no off-chain marketplace at all', () => {
+    let chainId: ChainId
+
+    beforeEach(() => {
+      chainId = ChainId.ARBITRUM_MAINNET
+    })
+
+    it('should throw naming the chain', () => {
+      expect(() => getLatestOffChainMarketplaceContract(chainId)).toThrowError(
+        `No off-chain marketplace contract exists on chain ${chainId}`
+      )
     })
   })
 })

--- a/src/lib/trades.spec.ts
+++ b/src/lib/trades.spec.ts
@@ -153,10 +153,8 @@ describe('when getting the trade signature', () => {
       } as Omit<TradeCreation, 'signature'>
     })
 
-    it.skip('should throw an error', async () => {
-      await expect(getTradeSignature(trade)).rejects.toThrowError(
-        'Could not get a valid contract for OffChainMarketplace using chain 42161'
-      )
+    it('should throw naming the chain that has no off-chain marketplace', async () => {
+      await expect(getTradeSignature(trade)).rejects.toThrowError('No off-chain marketplace contract exists on chain 42161')
     })
   })
 

--- a/src/lib/trades.ts
+++ b/src/lib/trades.ts
@@ -45,12 +45,38 @@ export const OFFCHAIN_MARKETPLACE_TYPES: Record<string, TypedDataField[]> = {
   ]
 }
 
+/**
+ * Off-chain marketplace versions, newest first.
+ *
+ * The EIP-712 domain names its verifying contract, so the version a trade is signed against is part of
+ * what the signer signed. Trades should settle on the newest deployment, but V3 is testnet-only for now,
+ * so mainnet has to keep using V2 rather than fail.
+ */
+const OFF_CHAIN_MARKETPLACE_CONTRACT_NAMES = [ContractName.OffChainMarketplaceV3, ContractName.OffChainMarketplaceV2]
+
+/**
+ * The newest off-chain marketplace deployed on a chain.
+ *
+ * `getContract` THROWS for a version that is not deployed on the given chain rather than returning a
+ * falsy value, which is why each candidate is tried in turn.
+ */
+export function getLatestOffChainMarketplaceContract(chainId: ChainId): ContractData {
+  for (const contractName of OFF_CHAIN_MARKETPLACE_CONTRACT_NAMES) {
+    try {
+      return getContract(contractName, chainId)
+    } catch (_error) {
+      continue
+    }
+  }
+  throw new Error(`No off-chain marketplace contract exists on chain ${chainId}`)
+}
+
 export async function getOffChainMarketplaceContract(chainId: ChainId) {
   const provider = await getNetworkProvider(chainId)
   if (!provider) {
     throw new Error('Could not get connected provider')
   }
-  const { address, abi } = getContract(ContractName.OffChainMarketplaceV2, chainId)
+  const { address, abi } = getLatestOffChainMarketplaceContract(chainId)
   const instance = new Contract(address, abi, new Web3Provider(provider))
   return instance
 }
@@ -144,11 +170,7 @@ export function getOnChainTrade(trade: Trade, sentBeneficiaryAddress: string): O
 }
 
 export async function getTradeSignature(trade: Omit<TradeCreation, 'signature'>) {
-  const marketplaceContract: ContractData = getContract(ContractName.OffChainMarketplaceV2, trade.chainId)
-
-  if (!marketplaceContract) {
-    throw new Error(`The ${ContractName.OffChainMarketplace} contract doesn't exist on chain ${trade.chainId}`)
-  }
+  const marketplaceContract: ContractData = getLatestOffChainMarketplaceContract(trade.chainId)
 
   const signer = (await getSigner()) as JsonRpcSigner
   const SALT = hexZeroPad(hexlify(trade.chainId), 32)


### PR DESCRIPTION
Reapplies #819, which was reverted in #821. The revert PR recorded no reason and neither PR carries a comment explaining it, so if it was reverted for a real failure rather than to unblock a release, please say so and I'll close this.

## What it does

`getOffChainMarketplaceContract` and `getTradeSignature` were pinned to `OffChainMarketplaceV2`. They now resolve the newest version deployed on the chain, so testnets sign against V3 while mainnet keeps V2 until V3 ships there.

Resolution is a fallback list rather than a switch because `getContract` throws for a version a chain does not have, and V3 is testnet-only. An unconditional switch would break every mainnet listing.

Also drops a dead `if (!marketplaceContract)` branch that could never run, since `getContract` throws rather than returning a falsy value, and whose message named the wrong contract.

## On the dependency bump

`decentraland-transactions` `^3.0.2` → `^3.1.1` is required, not incidental: `ContractName.OffChainMarketplaceV3` does not exist before 3.1.0, and 3.1.1 is the first release whose root import no longer pulls the optional `@0xsquid/sdk` peer.

## Verification

Diff is byte-identical to the reverted #819. On current `master`: build clean, `eslint` clean, full suite green (51 suites, 704 passed / 1 skipped), including the three cases added for the new resolver.
