### PR TITLE
feat: deliver analytics events to a first party ingestion host

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,7 +895,18 @@ const analyticsMiddleware = createAnalyticsMiddleware('SEGMENT WRITE KEY', {
 
 `analytics.js` fetches its settings from the origin of that URL. Pass `cdnUrl` as well when the proxy serves them from a different host.
 
-Both decide where a third party script is loaded from, so they are meant to be trusted URLs that come from the build configuration of the dapp, never from user input. Values that are not valid URLs, or that are not served over HTTPS unless they belong to the dapp's own origin, are ignored with a warning and the bundle keeps loading from Segment's CDN.
+The events themselves keep being delivered to Segment's ingestion endpoint, which the same filter lists drop. Pass `apiHost` to deliver them through the proxy too:
+
+```ts
+const analyticsMiddleware = createAnalyticsMiddleware('SEGMENT WRITE KEY', {
+  analyticsUrl: 'https://analytics.example.org/aPath/aBundle.min.js',
+  apiHost: 'api.example.org/v1'
+})
+```
+
+`apiHost` takes no protocol: `analytics.js` prepends it and appends the method path (`/t`, `/i`, `/p`), so the value is shaped `host/basePath`. A value that carries a protocol is accepted and stripped.
+
+The three of them decide where a third party script is loaded from and where every event is delivered, so they are meant to be trusted values that come from the build configuration of the dapp, never from user input. Values that are not valid URLs, or that are not served over HTTPS unless they belong to the dapp's own origin, are ignored with a warning and analytics degrades to Segment's own CDN and ingestion.
 
 **Saga**:
 

--- a/src/modules/analytics/middleware.spec.ts
+++ b/src/modules/analytics/middleware.spec.ts
@@ -1,0 +1,65 @@
+import { createAnalyticsMiddleware } from './middleware'
+import { installAnalyticsSnippet } from './snippet'
+import { resetMiddlewareRegistration } from './utils'
+
+const ANALYTICS_URL = 'https://analytics.example.com/aPath/aBundle.min.js'
+const API_HOST = 'api.example.com/v1'
+const API_KEY = 'anApiKey'
+
+const anyWindow = window as unknown as { analytics: any }
+
+describe('when creating the analytics middleware', () => {
+  beforeEach(() => {
+    delete (window as any).analytics
+    document.head.innerHTML = ''
+    document.body.innerHTML = ''
+    resetMiddlewareRegistration()
+    installAnalyticsSnippet()
+  })
+
+  describe('and no options are given', () => {
+    it('should load analytics.js without options, so the events keep going to segment ingestion', () => {
+      createAnalyticsMiddleware(API_KEY)
+
+      expect(anyWindow.analytics._writeKey).toBe(API_KEY)
+      expect(anyWindow.analytics._loadOptions).toBeUndefined()
+    })
+  })
+
+  describe('and an api host is given', () => {
+    it('should load analytics.js delivering the events to it', () => {
+      createAnalyticsMiddleware(API_KEY, { analyticsUrl: ANALYTICS_URL, apiHost: API_HOST })
+
+      expect(anyWindow.analytics._loadOptions).toEqual({ integrations: { 'Segment.io': { apiHost: API_HOST } } })
+    })
+  })
+
+  describe('and analytics.js is already loaded on the page, so the snippet is not the one loading it', () => {
+    let load: jest.Mock
+
+    beforeEach(() => {
+      load = jest.fn()
+      anyWindow.analytics = {
+        initialize: true,
+        load,
+        addSourceMiddleware: jest.fn()
+      }
+    })
+
+    describe('and an api host is given', () => {
+      it('should pass it to load as the integrations settings of the segment destination', () => {
+        createAnalyticsMiddleware(API_KEY, { apiHost: API_HOST })
+
+        expect(load).toHaveBeenCalledWith(API_KEY, { integrations: { 'Segment.io': { apiHost: API_HOST } } })
+      })
+    })
+
+    describe('and no options are given', () => {
+      it('should pass no load options', () => {
+        createAnalyticsMiddleware(API_KEY)
+
+        expect(load).toHaveBeenCalledWith(API_KEY, undefined)
+      })
+    })
+  })
+})

--- a/src/modules/analytics/middleware.ts
+++ b/src/modules/analytics/middleware.ts
@@ -1,5 +1,5 @@
 import { RootMiddleware } from '../../types'
-import { AnalyticsSnippetOptions, configureAnalyticsSnippet } from './snippet'
+import { AnalyticsSnippetOptions, configureAnalyticsSnippet, getAnalyticsLoadOptions } from './snippet'
 import { getAnalytics, track } from './utils'
 
 const disabledMiddleware: RootMiddleware = _ => next => action => {
@@ -19,7 +19,9 @@ export function createAnalyticsMiddleware(apiKey: string, options?: AnalyticsSni
   }
 
   configureAnalyticsSnippet(options)
-  analytics.load(apiKey)
+  // Passed explicitly because analytics.js may already be on the page, in which case `load` is its own and not the
+  // snippet's, so it reads nothing from the options configured above
+  analytics.load(apiKey, getAnalyticsLoadOptions())
 
   return _ => next => action => {
     track(action)

--- a/src/modules/analytics/snippet.spec.ts
+++ b/src/modules/analytics/snippet.spec.ts
@@ -312,6 +312,46 @@ describe('Analytics Snippet', () => {
     })
   })
 
+  describe('when the snippet is configured with a bare api host, no base path', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ apiHost: 'api.example.com' })
+    })
+
+    it('should deliver the events to it without leaving a trailing slash behind', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(anyWindow.analytics._loadOptions).toEqual({ integrations: { 'Segment.io': { apiHost: 'api.example.com' } } })
+    })
+  })
+
+  describe('when the snippet is configured with an api host and load carries options other than integrations', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ apiHost: API_HOST })
+    })
+
+    it('should keep them, only the segment destination settings are its business', () => {
+      anyWindow.analytics.load(WRITE_KEY, { obfuscate: true, initialPageview: false })
+
+      expect(anyWindow.analytics._loadOptions).toEqual({
+        obfuscate: true,
+        initialPageview: false,
+        integrations: { 'Segment.io': { apiHost: API_HOST } }
+      })
+    })
+  })
+
+  describe('when the load options already went through the api host merge, as the analytics middleware does', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ apiHost: API_HOST })
+    })
+
+    it('should leave them as they are, applying it twice is the same as applying it once', () => {
+      const alreadyMerged = getAnalyticsLoadOptions()
+
+      expect(getAnalyticsLoadOptions(alreadyMerged)).toEqual({ integrations: { 'Segment.io': { apiHost: API_HOST } } })
+    })
+  })
+
   describe('when reading the load options of a snippet configured with an api host', () => {
     beforeEach(() => {
       configureAnalyticsSnippet({ apiHost: API_HOST })

--- a/src/modules/analytics/snippet.spec.ts
+++ b/src/modules/analytics/snippet.spec.ts
@@ -1,6 +1,7 @@
-import { configureAnalyticsSnippet, installAnalyticsSnippet } from './snippet'
+import { configureAnalyticsSnippet, getAnalyticsLoadOptions, installAnalyticsSnippet } from './snippet'
 
 const ANALYTICS_URL = 'https://analytics.example.com/aPath/aBundle.min.js'
+const API_HOST = 'api.example.com/v1'
 const WRITE_KEY = 'aWriteKey'
 
 const anyWindow = window as unknown as { analytics: any }
@@ -203,6 +204,127 @@ describe('Analytics Snippet', () => {
 
     it('should keep the snippet that was already installed and warn about it', () => {
       expect(consoleError).toHaveBeenCalledWith('Segment snippet included twice.')
+    })
+  })
+
+  describe('when the snippet is not configured with an api host', () => {
+    it('should load without options, so the events keep going to segment ingestion', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(anyWindow.analytics._loadOptions).toBeUndefined()
+    })
+
+    it('should keep the load options it was called with untouched', () => {
+      anyWindow.analytics.load(WRITE_KEY, { integrations: { 'Google Analytics': false } })
+
+      expect(anyWindow.analytics._loadOptions).toEqual({ integrations: { 'Google Analytics': false } })
+    })
+  })
+
+  describe('when the snippet is configured with an api host', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ apiHost: API_HOST })
+    })
+
+    it('should deliver the events to it', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(anyWindow.analytics._loadOptions).toEqual({ integrations: { 'Segment.io': { apiHost: API_HOST } } })
+    })
+
+    it('should merge it into the load options it was called with', () => {
+      anyWindow.analytics.load(WRITE_KEY, { integrations: { 'Google Analytics': false } })
+
+      expect(anyWindow.analytics._loadOptions).toEqual({
+        integrations: { 'Google Analytics': false, 'Segment.io': { apiHost: API_HOST } }
+      })
+    })
+  })
+
+  describe('when the snippet is configured with an api host and load already carries settings for the segment destination', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ apiHost: API_HOST })
+    })
+
+    it('should keep the settings it was called with', () => {
+      anyWindow.analytics.load(WRITE_KEY, { integrations: { 'Segment.io': { deliveryStrategy: { strategy: 'batching' } } } })
+
+      expect(anyWindow.analytics._loadOptions).toEqual({
+        integrations: { 'Segment.io': { deliveryStrategy: { strategy: 'batching' }, apiHost: API_HOST } }
+      })
+    })
+
+    it('should replace a boolean toggle rather than spreading it into the settings', () => {
+      anyWindow.analytics.load(WRITE_KEY, { integrations: { 'Segment.io': true } })
+
+      expect(anyWindow.analytics._loadOptions).toEqual({ integrations: { 'Segment.io': { apiHost: API_HOST } } })
+    })
+  })
+
+  describe.each([
+    ['carries a protocol', `https://${API_HOST}`],
+    ['carries a trailing slash', `${API_HOST}/`]
+  ])('when the snippet is configured with an api host that %s', (_case, apiHost) => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ apiHost })
+    })
+
+    it('should strip it, analytics.js prepends the protocol and appends the method path itself', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(anyWindow.analytics._loadOptions).toEqual({ integrations: { 'Segment.io': { apiHost: API_HOST } } })
+    })
+  })
+
+  describe.each([
+    ['malformed', 'https://['],
+    ['not served over https', 'http://api.example.com/v1']
+  ])('when the snippet is configured with an api host that is %s', (_case, apiHost) => {
+    let consoleWarn: jest.SpyInstance
+
+    beforeEach(() => {
+      consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+      configureAnalyticsSnippet({ apiHost })
+    })
+
+    afterEach(() => {
+      consoleWarn.mockRestore()
+    })
+
+    it('should warn about it and leave the events going to segment ingestion', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(consoleWarn).toHaveBeenCalled()
+      expect(anyWindow.analytics._loadOptions).toBeUndefined()
+    })
+  })
+
+  describe('when the snippet is reconfigured without an api host', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ apiHost: API_HOST })
+      configureAnalyticsSnippet()
+    })
+
+    it('should stop delivering the events to the previous api host', () => {
+      anyWindow.analytics.load(WRITE_KEY)
+
+      expect(anyWindow.analytics._loadOptions).toBeUndefined()
+    })
+  })
+
+  describe('when reading the load options of a snippet configured with an api host', () => {
+    beforeEach(() => {
+      configureAnalyticsSnippet({ apiHost: API_HOST })
+    })
+
+    it('should return the integrations settings analytics.js delivers the events with', () => {
+      expect(getAnalyticsLoadOptions()).toEqual({ integrations: { 'Segment.io': { apiHost: API_HOST } } })
+    })
+  })
+
+  describe('when reading the load options of a snippet configured without an api host', () => {
+    it('should return nothing, so a caller passing them along changes no default', () => {
+      expect(getAnalyticsLoadOptions()).toBeUndefined()
     })
   })
 })

--- a/src/modules/analytics/snippet.ts
+++ b/src/modules/analytics/snippet.ts
@@ -9,12 +9,31 @@ export type AnalyticsSnippetOptions = {
    * serving both the bundle and the settings needs.
    */
   cdnUrl?: string
+  /**
+   * Host the events are delivered to, without a protocol (`host/basePath`). Defaults to Segment's ingestion endpoint,
+   * which ad blockers drop just like its CDN, so dapps can point it at a first party proxy instead. Example:
+   * `api.example.com/v1`.
+   *
+   * analytics.js prepends the protocol and appends the method path (`/t`, `/i`, `/p`), it takes neither of them here.
+   */
+  apiHost?: string
+}
+
+type SegmentIntegrationSettings = boolean | Record<string, unknown>
+
+export type AnalyticsLoadOptions = {
+  integrations?: Record<string, SegmentIntegrationSettings>
+  [key: string]: unknown
 }
 
 type SegmentSnippet = any[] & Record<string, any>
 
 const GLOBAL_ANALYTICS_KEY = 'analytics'
 const SNIPPET_VERSION = '5.2.0'
+// Name of the analytics.js integration that delivers the events to Segment, the one carrying the ingestion host
+const SEGMENT_IO = 'Segment.io'
+const PROTOCOL_PREFIX = /^[a-z][a-z0-9+.-]*:\/\//i
+const TRAILING_SLASHES = /\/+$/
 
 // Methods stubbed by the snippet, so calls made before analytics.js loads are queued and replayed afterwards
 const METHODS = [
@@ -76,6 +95,38 @@ function resolveUrl(name: string, url: string) {
 }
 
 /**
+ * Normalizes the host the events are delivered to. analytics.js takes it without a protocol (`host/basePath`) and
+ * prepends one, so a value that carries it is accepted and stripped instead of producing `https://https://host`.
+ */
+function resolveApiHost(apiHost: string) {
+  const resolved = resolveUrl('api host', PROTOCOL_PREFIX.test(apiHost) ? apiHost : `https://${apiHost}`)
+
+  return resolved && `${resolved.host}${resolved.pathname}`.replace(TRAILING_SLASHES, '')
+}
+
+/**
+ * Merges the configured first party ingestion host into the given load options, keeping the rest of them and the other
+ * integrations untouched, and returns them as they came when there is none so Segment's own ingestion stays in place.
+ * Exported for dapps that call `analytics.load` themselves instead of going through the analytics middleware.
+ */
+export function getAnalyticsLoadOptions(loadOptions?: AnalyticsLoadOptions): AnalyticsLoadOptions | undefined {
+  if (!options.apiHost) return loadOptions
+
+  const segmentIo = loadOptions?.integrations?.[SEGMENT_IO]
+
+  return {
+    ...loadOptions,
+    integrations: {
+      ...loadOptions?.integrations,
+      [SEGMENT_IO]: {
+        ...(typeof segmentIo === 'object' ? segmentIo : undefined),
+        apiHost: options.apiHost
+      }
+    }
+  }
+}
+
+/**
  * Points the snippet at a different analytics.js bundle. Takes effect on the next `analytics.load` call, so it must
  * run before the analytics middleware is created.
  */
@@ -87,6 +138,7 @@ export function configureAnalyticsSnippet(newOptions: AnalyticsSnippetOptions = 
 
   options.analyticsUrl = analyticsUrl?.href
   options.cdnUrl = cdnUrl ? newOptions.cdnUrl : analyticsUrl?.origin
+  options.apiHost = newOptions.apiHost ? resolveApiHost(newOptions.apiHost) : undefined
 
   const analytics = (window as unknown as { analytics?: SegmentSnippet }).analytics
 
@@ -156,7 +208,7 @@ export function installAnalyticsSnippet() {
     analytics[method] = analytics.factory(method)
   }
 
-  analytics.load = (writeKey: string, loadOptions?: unknown) => {
+  analytics.load = (writeKey: string, loadOptions?: AnalyticsLoadOptions) => {
     const script = document.createElement('script')
     script.type = 'text/javascript'
     script.async = true
@@ -171,7 +223,8 @@ export function installAnalyticsSnippet() {
     }
 
     analytics._writeKey = writeKey
-    analytics._loadOptions = loadOptions
+    // analytics.js reads the ingestion host from here once the bundle it just injected boots
+    analytics._loadOptions = getAnalyticsLoadOptions(loadOptions)
   }
 
   if (options.cdnUrl) {

--- a/src/modules/analytics/snippet.ts
+++ b/src/modules/analytics/snippet.ts
@@ -223,7 +223,9 @@ export function installAnalyticsSnippet() {
     }
 
     analytics._writeKey = writeKey
-    // analytics.js reads the ingestion host from here once the bundle it just injected boots
+    // analytics.js reads the ingestion host from here once the bundle it just injected boots. Applied even
+    // though the analytics middleware already applied it to what it passes: callers that load the snippet
+    // themselves never go through it, and merging the same host twice yields the same options.
     analytics._loadOptions = getAnalyticsLoadOptions(loadOptions)
   }
 


### PR DESCRIPTION
Ad blockers match Segment's hosts, so the migration to a first party proxy is only half done for the dapps that go through this package. Marketplace and Builder already load `analytics.js` and its settings from the proxy via `analyticsUrl` / `cdnUrl`, but every event still POSTs to `api.segment.io`, which the same filter lists block. `@dcl/hooks` already exposes the equivalent option for React apps (`AnalyticsProvider`'s `apiHost`), and dapps on this snippet had no way to pass it.

What changes:

- `AnalyticsSnippetOptions` gains `apiHost`, the host events are delivered to, without a protocol and shaped `host/basePath` (for example `api.example.org/v1`), because `analytics.js` prepends the protocol and appends the method path (`/t`, `/i`, `/p`).
- It is validated like `analyticsUrl` and `cdnUrl` are: it must resolve to an https URL, a value carrying a protocol is accepted and stripped rather than producing `https://https://host`, and an invalid or plain http value is dropped with a console warning so the dapp degrades to Segment's own ingestion instead of pointing the SDK at an untrusted host. Same normalization as `resolveApiHost` in `@dcl/hooks`.
- The snippet's `analytics.load` forwards it as `integrations['Segment.io'].apiHost`, merged into whatever load options the caller passed and only when a valid `apiHost` is configured.
- `createAnalyticsMiddleware` now passes those load options to `load`, which it was dropping. This matters when `analytics.js` is already on the page, since then `load` is its own and reads nothing from the snippet.
- New `getAnalyticsLoadOptions`, for dapps that call `analytics.load` themselves instead of going through the middleware.

No feature flag is read here. Each app evaluates its own flag and decides whether to pass the proxy options, so this PR is only the capability.

How to test it:

- `npm test` covers the new behaviour in `src/modules/analytics/snippet.spec.ts` and `src/modules/analytics/middleware.spec.ts`: a configured `apiHost` reaching `load`'s integrations, a protocol-carrying or trailing-slash value being normalized, an invalid or http value being dropped with a warning, and omitting it leaving `load` exactly as it is today.
- In a dapp, link this branch and pass `apiHost` to `createAnalyticsMiddleware` alongside `analyticsUrl`. The events in the network tab should POST to `https://<apiHost>/t` instead of `https://api.segment.io/v1/t`. Without `apiHost` they should keep going to `api.segment.io`.
